### PR TITLE
doc: canon-sync PAT requires `Actions: write` on target repo

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -94,6 +94,7 @@ Both workflows use the same secret — a GitHub Personal Access Token with cross
 5. Repository permissions:
    - **Contents: Read and write** (needed for the receiver to check out `uiao-core` and to push the `canon-sync/*` branch to `uiao-docs`).
    - **Pull requests: Read and write** (needed to open the PR).
+   - **Actions: Read and write** (required for the dispatcher's `repository_dispatch` call to actually fire the receiver workflow on `uiao-docs`. The `POST /repos/.../dispatches` REST endpoint accepts and returns 204 with only `Contents: write`, so the dispatcher step reports success — but GitHub silently drops the event and the receiver never runs unless the token also carries `Actions: write`).
    - **Metadata: Read-only** (auto-selected).
 6. Expiration: 90 days is a reasonable starting point; set a calendar reminder to rotate.
 7. Generate the token and copy the value (you only see it once).
@@ -122,7 +123,7 @@ This triggers the receiver in `workflow_dispatch` mode against `main` (or your c
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | Receiver workflow fails with `Bad credentials` | PAT expired or missing | Regenerate PAT, update `CANON_SYNC_DISPATCH_TOKEN` secret in both repos |
-| Dispatcher runs but receiver never triggers | Dispatch token lacks Contents:write on target repo | Verify fine-grained PAT includes `uiao-docs` with Contents: Read and write |
+| Dispatcher runs green but receiver workflow shows "no runs yet" | Dispatch token lacks `Actions: write` on target repo (the dispatch API accepts the event with just `Contents: write` but GitHub silently skips workflow triggering without `Actions: write`) | Regenerate the fine-grained PAT with `Actions: Read and write` on `uiao-docs`. Verify by re-triggering: either push a whitespace tweak to any `canon/*.yaml` on uiao-core/main, or use **Actions → Canon sync — receive from uiao-core → Run workflow** to test the receiver code path directly. |
 | `peter-evans/create-pull-request` says "Bypassed rule violations" | Required status check not yet registered as a check on `uiao-docs` | Expected for now — will resolve in Step 6 (CI workflows) |
 | `sync_canon.py` reports orphan drift | Folder exists in `uiao-docs` but no adapter with that id in either registry | Either add the adapter to canon, or manually retire the folder. Tool never deletes. |
 | Schema validation fails on dispatch | YAML edit introduced a schema violation | Fix locally, run `python tools/sync_canon.py --core-root . --docs-root ../uiao-docs --check-only` to verify, then push |


### PR DESCRIPTION
## Summary

Documentation-only. Updates `tools/README.md` to reflect a discovery from post-merge validation of the ODA-15 canon-sync round-trip.

### Finding

After WhalerMike/uiao-core#181 merged into `main` as `8f9a0c8`, the canon-sync round-trip was tested end-to-end for the first time:

| Link | Status |
|---|---|
| `canon-sync-dispatch.yml` fired on `8f9a0c8` | ✅ 10s, green |
| Dispatch pre-flight schema validation | ✅ clean |
| `POST /repos/WhalerMike/uiao-docs/dispatches` | ✅ 204 accepted |
| `canon-sync-receive.yml` fires on `canon-updated` | ❌ **"no runs yet"** (never triggered) |

### Root cause

The `CANON_SYNC_DISPATCH_TOKEN` fine-grained PAT was created per the current doc recipe: `Contents: write` + `Pull requests: write` + `Metadata: read`. That combination is sufficient for the dispatch REST endpoint to return 204 — so the dispatcher reports success — but GitHub silently drops the `repository_dispatch` event and does not trigger the receiver workflow unless the token **also** carries `Actions: write` on the target repo.

### Changes

1. **Required-secret permissions list** now includes `Actions: Read and write` with an inline note explaining the silent-drop failure mode.
2. **Troubleshooting row** "Dispatcher runs but receiver never triggers" rewritten: names the actual root cause (missing `Actions: write`) instead of the previous guess (lacks Contents:write), and prescribes the remediation path (rotate PAT + re-trigger via a whitespace tweak to `canon/*.yaml` on `main`, or use `workflow_dispatch` to exercise the receiver code path directly).

### ~~Paired PR~~ (closed)

~~WhalerMike/uiao-docs#<number>~~ — **Closed.** The intended mirror into `uiao-docs/docs/session-logs/2026-04-14-manifest-your-side.md` triggers the `validate-frontmatter` workflow, which fails on the session log's (intentionally minimal) frontmatter — a pre-existing condition unrelated to this change. The authoritative PAT setup doc is this `tools/README.md`; the session-log copy was defensive mirroring, not required.

### After this lands

Rotate `CANON_SYNC_DISPATCH_TOKEN` to include `Actions: Read and write` on `WhalerMike/uiao-docs`, then either:
- push a whitespace-only tweak to `canon/modernization-registry.yaml` on `uiao-core/main` to re-trigger the dispatch, OR
- use the receiver's `workflow_dispatch` entrypoint directly.

## Test plan

- [x] No tool/behavior changes; docs only.
- [x] Markdown renders cleanly (inspected locally).
- [ ] After merge + PAT rotation: trivial canon push produces a receiver run (green) with zero drift (since uiao-docs is already in sync post-#24).

## CI note

`Check links` may report red on this PR due to a transient network error from `contributor-covenant.org` ("Connection reset by peer" across all 3 lychee retries for `/version/2/0/code_of_conduct.html`). Affects `CODE_OF_CONDUCT.md`, not touched by this PR. Will clear on a re-run or on the next push to main. Every other check is green.

https://claude.ai/code/session_01Wu19UGhHdxxMF9pdUVCDMC