### PR TITLE
ci: bump actions/cache + upload-artifact v4 → v5 (Node.js 24)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Restore lychee cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .lycheecache
           # Include .lychee.toml hash in the key so config changes (e.g. a new
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: lychee-report
           path: lychee-report.md


### PR DESCRIPTION
## Summary

Item 16 of the 25-item approved list. Bumps `actions/cache` and `actions/upload-artifact` from v4 to v5 in `link-check.yml` to clear the Node.js 20 deprecation warning that fires on every CI run.

> "Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026."

No behavior change; same cache/artifact semantics with Node.js 24 support.

https://claude.ai/code/session_01Wu19UGhHdxxMF9pdUVCDMC