### PR TITLE
FIMF Tier 5: mainframe + pki-ca + siem adapter registry entries

### DIFF
--- a/canon/adapter-registry.yaml
+++ b/canon/adapter-registry.yaml
@@ -246,3 +246,86 @@ adapters:
       Microsoft Graph API (Intune device compliance + Defender for
       Endpoint). Natural complement to the m365 modernization adapter.
       Read-only — observes device state, never mutates configuration.
+
+  - id: pki-ca
+    name: PKI / Certificate Authority Adapter
+    class: conformance
+    mission-class: telemetry
+    status: reserved
+    phase: phase-planning
+    vendor: Generic
+    license: Open Source
+    runtime: python-3.12
+    runner-class: github-hosted
+    tenancy: per-customer
+    scope:
+      - piv-certificates
+      - tls-certificates
+      - ocsp-responses
+      - crl-distribution
+    outputs:
+      - certificate-inventory.json
+      - expiry-report.json
+    triggers:
+      - workflow_dispatch
+      - schedule
+    evidence-class: interval
+    retention-years: 3
+    controls:
+      - IA-5
+      - SC-12
+      - SC-13
+    automation-domain:
+      - configuration-management
+    gcc-boundary: gcc-moderate
+    ssot-mutation: never
+    certificate-anchored: true
+    object-identity-only: true
+    references:
+      - UIAO-CANON-003
+    notes: >-
+      FIMF Tier 5 conformance adapter. Observes certificate state
+      via OCSP, CRL, and PKI APIs. Critical for the certificate-
+      anchored provenance model.
+
+  - id: siem
+    name: SIEM / Audit Event Adapter
+    class: conformance
+    mission-class: telemetry
+    status: reserved
+    phase: phase-planning
+    vendor: Generic
+    license: Open Source
+    runtime: python-3.12
+    runner-class: github-hosted
+    tenancy: per-customer
+    scope:
+      - audit-events
+      - security-alerts
+      - log-aggregation
+    outputs:
+      - audit-event-claims.json
+      - alert-summary.json
+    triggers:
+      - workflow_dispatch
+      - repository_dispatch
+      - schedule
+    evidence-class: interval
+    retention-years: 3
+    controls:
+      - AU-2
+      - AU-3
+      - AU-6
+      - SI-4
+    automation-domain:
+      - event-management
+    gcc-boundary: gcc-moderate
+    ssot-mutation: never
+    certificate-anchored: true
+    object-identity-only: true
+    references:
+      - UIAO-CANON-003
+    notes: >-
+      FIMF Tier 5 conformance adapter. Ingests audit events and
+      security alerts from SIEM platforms (Sentinel, Splunk, etc.).
+      Highest-value telemetry adapter for the evidence fabric.

--- a/canon/modernization-registry.yaml
+++ b/canon/modernization-registry.yaml
@@ -384,3 +384,45 @@ adapters:
     notes: >-
       Tier 4 adapter. Requires on-prem-self-hosted runner with network
       access to Infoblox WAPI.
+
+  - id: mainframe
+    name: Mainframe (z/OS Connect / MQ) Adapter
+    class: modernization
+    mission-class: integration
+    mission-class-notes: >-
+      Legacy mainframe integration — maps COBOL records and MQ messages
+      to canonical claims via z/OS Connect or MQ bridge. Highest-priority
+      FIMF adapter for federal legacy migration use cases.
+    status: reserved
+    phase: phase-planning
+    vendor: IBM
+    license: Commercial
+    runtime: python-3.12
+    runner-class: on-prem-self-hosted
+    tenancy: per-customer
+    scope:
+      - cobol-records
+      - mq-messages
+      - cics-transactions
+    outputs:
+      - mainframe-claim-manifest.json
+    triggers:
+      - workflow_dispatch
+      - repository_dispatch
+    evidence-class: baseline
+    retention-years: 3
+    controls:
+      - CM-8
+      - AC-2
+      - AU-2
+    automation-domain:
+      - asset-management
+    gcc-boundary: gcc-moderate
+    ssot-mutation: never
+    certificate-anchored: true
+    object-identity-only: true
+    references:
+      - UIAO-CANON-003
+    notes: >-
+      FIMF Tier 5 adapter. Requires z/OS Connect or MQ bridge
+      infrastructure. Highest-priority legacy migration adapter.


### PR DESCRIPTION
## Summary

FIMF Tier 5: three new reserved adapter slots from the Federated Identity Management Framework long-horizon roadmap.

| Adapter | Registry | Class | Mission | Controls | Priority |
|---|---|---|---|---|---|
| `mainframe` | modernization | integration | CM-8, AC-2, AU-2 | Highest (legacy migration) |
| `pki-ca` | conformance | telemetry | IA-5, SC-12, SC-13 | High (certificate-anchored provenance) |
| `siem` | conformance | telemetry | AU-2, AU-3, AU-6, SI-4 | High (evidence fabric) |

Total: 16 adapters (9 modernization + 7 conformance). Schema validates clean.

https://claude.ai/code/session_01Wu19UGhHdxxMF9pdUVCDMC