### PR TITLE
Add multi-repo Claude kit, WORKSPACE.md, and workspace path migration

### DIFF
--- a/.claude/agents/appendix-manager.md
+++ b/.claude/agents/appendix-manager.md
@@ -1,0 +1,26 @@
+---
+name: appendix-manager
+description: Indexes and syncs appendix artifacts. Invoke via /appendix.
+tools: Bash, Read, Glob, Grep, Edit
+---
+
+# Appendix Manager
+
+Responsible for the meta-appendix index and cross-repo appendix sync.
+
+Actions:
+
+1. Run `python tools/appendix_indexer.py` to regenerate the appendix index.
+2. Verify every artifact under `appendices/` has:
+   - Valid frontmatter (title, id, version, owner, source).
+   - A reference from at least one canon document or ADR.
+3. Report orphan appendices (no inbound references) and dangling references (canon pointing at missing appendices).
+4. For the docs repo (`uiao-docs`), the appendix set mirrors `uiao-core/appendices/` plus `uiao-docs/appendices/`. Flag divergence.
+
+Commit convention when indexer regenerates files:
+
+```
+[UIAO-CORE] UPDATE: appendix-index — regenerate from <N> artifacts
+```
+
+Only regenerate when explicitly asked. Read-only by default.

--- a/.claude/agents/canon-steward.md
+++ b/.claude/agents/canon-steward.md
@@ -1,0 +1,31 @@
+---
+name: canon-steward
+description: Full canon integrity check — runs validate, drift, appendix, dashboard in order. Invoke via /canon.
+tools: Bash, Read, Glob, Grep
+---
+
+# Canon Steward
+
+Master integrity check. Composes the other four agents and produces a single report.
+
+Sequence:
+
+1. **Structure** — `python tools/validators/structure_validator.py` (directory contract).
+2. **Schemas** — `python scripts/validate_schemas.py` (every JSON Schema parses).
+3. **Canon** — `python scripts/validate_canon.py` (canonical IDs unique and referenced).
+4. **Metadata** — `python tools/metadata_validator.py` (frontmatter conforms).
+5. **Drift** — `python tools/drift_detector.py` (no unmanaged divergence).
+6. **Crosswalks** — `python tools/validators/crosswalk_validator.py` (KSI↔control, control↔adapter).
+7. **Appendix** — `python tools/appendix_indexer.py --check` (index current).
+8. **Dashboard** — `python tools/dashboard_exporter.py --validate` (export would succeed).
+
+Report:
+
+- Overall PASS/FAIL.
+- Per-stage status with timing.
+- Consolidated finding list, deduplicated across stages.
+- Blocking vs. non-blocking classification.
+
+Exit non-zero only if a blocking stage fails. Non-blocking findings go to the report and a GitHub issue draft.
+
+Does not write any artifact. Canon mutations require an explicit PR.

--- a/.claude/agents/dashboard-exporter.md
+++ b/.claude/agents/dashboard-exporter.md
@@ -1,0 +1,24 @@
+---
+name: dashboard-exporter
+description: Exports the governance dashboard per schemas/dashboard-schema.json. Invoke via /dashboard.
+tools: Bash, Read, Glob
+---
+
+# Dashboard Exporter
+
+Generate the governance dashboard JSON for downstream consumers (uiao-docs, uiao-gos, uiao-impl).
+
+Actions:
+
+1. Run `python tools/dashboard_exporter.py` which reads:
+   - `canon/modernization-registry.yaml`
+   - `canon/adapter-registry.yaml`
+   - `rules/ksi/index.yaml`
+   - `data/control-library/index.yaml`
+   - POA&M findings under `canon/data/poam-findings.yml`
+2. Validate output against `schemas/dashboard-schema.json`.
+3. Write timestamped export to `dashboard/exports/dashboard-YYYY-MM-DD.json`.
+
+If the schema validation fails, do not write the export. Report which fields are non-conforming with line numbers.
+
+Dashboard exports are consumed by `uiao-docs/analytics/atlas_dashboard.json` and `uiao-gos/core/governance/`. Breaking the schema is a cross-repo breaking change — flag it loudly.

--- a/.claude/agents/drift-detector.md
+++ b/.claude/agents/drift-detector.md
@@ -1,0 +1,23 @@
+---
+name: drift-detector
+description: Scans for metadata drift between canon and working artifacts. Invoke via /drift.
+tools: Bash, Read, Glob, Grep
+---
+
+# Drift Detector
+
+Run `python tools/drift_detector.py` and interpret the output.
+
+Drift categories to report:
+
+1. **Schema drift** — frontmatter keys in artifacts that are not in `schemas/metadata-schema.json`, or required keys missing.
+2. **Index drift** — KSI or control files present on disk but missing from their index, or vice versa.
+3. **Crosswalk drift** — entries in `rules/ksi/uiao-control-to-ksi-mapping.yaml` referencing controls or KSIs that do not exist.
+4. **Adapter drift** — adapter-registry entries without a matching overlay in `data/overlays/<vendor>/`.
+5. **Appendix drift** — appendix artifacts referenced in canon that are not indexed.
+
+Output a triage table:
+
+| Category | Count | Blocking? | Remediation |
+
+Do not mutate files. Propose a remediation plan; the user executes it.

--- a/.claude/agents/governance-agent.md
+++ b/.claude/agents/governance-agent.md
@@ -1,0 +1,23 @@
+---
+name: governance-agent
+description: Runs the full metadata validation suite across canon, rules, schemas, and data. Invoke via /validate.
+tools: Bash, Read, Glob, Grep
+---
+
+# Governance Agent
+
+Execute the metadata validation pipeline:
+
+1. `python tools/metadata_validator.py` — schema compliance for YAML/JSON frontmatter across `canon/`, `rules/`, `schemas/`, `data/`.
+2. `python scripts/validate_schemas.py` — JSON Schema validity for every file in `schemas/`.
+3. `python scripts/validate_canon.py` — canonical-ID uniqueness and cross-reference integrity.
+4. `python scripts/validate_numbering.py` — monotonic numbering for ADRs, KSIs, controls.
+5. `python scripts/validate_directory.py` — directory structure matches `tools/schema/directory_structure.yaml`.
+
+Report format:
+
+- Per-check PASS/FAIL with counts.
+- For failures: first 10 offending files with line numbers.
+- Exit non-zero if any check fails.
+
+Do not auto-fix. Surface findings; let the human decide.

--- a/.claude/commands/appendix.md
+++ b/.claude/commands/appendix.md
@@ -1,0 +1,16 @@
+---
+description: Index and sync appendices
+argument-hint: "[--regenerate]"
+---
+
+Invoke the `appendix-manager` agent.
+
+By default, runs in check-only mode: reports orphans, dangling references, and divergence between `uiao-core/appendices/` and `uiao-docs/appendices/`.
+
+With `--regenerate` in `$ARGUMENTS`, regenerates the appendix index and commits with:
+
+```
+[UIAO-CORE] UPDATE: appendix-index — regenerate from <N> artifacts
+```
+
+Mirrors `.github/workflows/appendix-sync.yml` (lives in `uiao-docs`).

--- a/.claude/commands/canon.md
+++ b/.claude/commands/canon.md
@@ -1,0 +1,10 @@
+---
+description: Full canon integrity check
+argument-hint: "[--blocking-only]"
+---
+
+Invoke the `canon-steward` agent to run the eight-stage integrity check (structure, schemas, canon, metadata, drift, crosswalks, appendix, dashboard).
+
+With `--blocking-only` in `$ARGUMENTS`, suppresses non-blocking findings in the report.
+
+This is the pre-PR gate. Run it before opening any PR that touches `canon/`, `rules/`, `schemas/`, or `data/`.

--- a/.claude/commands/dashboard.md
+++ b/.claude/commands/dashboard.md
@@ -1,0 +1,13 @@
+---
+description: Export governance dashboard
+argument-hint: "[--dry-run]"
+---
+
+Invoke the `dashboard-exporter` agent to generate a timestamped governance dashboard JSON under `dashboard/exports/`.
+
+With `--dry-run` in `$ARGUMENTS`, validates but does not write the export file.
+
+Schema: `schemas/dashboard-schema.json`.
+Consumers: `uiao-docs/analytics/atlas_dashboard.json`, `uiao-gos/core/governance/`.
+
+Mirrors `.github/workflows/dashboard-export.yml`.

--- a/.claude/commands/drift.md
+++ b/.claude/commands/drift.md
@@ -1,0 +1,10 @@
+---
+description: Scan for canon drift
+argument-hint: "[category]"
+---
+
+Invoke the `drift-detector` agent to scan for metadata, index, crosswalk, adapter, and appendix drift.
+
+If `$ARGUMENTS` specifies a category (`schema`, `index`, `crosswalk`, `adapter`, `appendix`), scope the scan to that category only. Otherwise run all five.
+
+Mirrors `.github/workflows/drift-scan.yml` and `.github/workflows/drift-detection.yml`.

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -1,0 +1,14 @@
+---
+description: Run metadata validation suite
+argument-hint: "[--fix]"
+---
+
+Invoke the `governance-agent` to run the full metadata validation pipeline over canon, rules, schemas, and data.
+
+If `$ARGUMENTS` contains `--fix`, the agent may propose auto-remediation patches but must not apply them without explicit approval.
+
+Expected CI gates this mirrors:
+
+- `.github/workflows/metadata-validator.yml`
+- `.github/workflows/canon-validation.yml`
+- `.github/workflows/validate-workflow-serialization.yml`

--- a/.claude/rules/00-no-hallucination.md
+++ b/.claude/rules/00-no-hallucination.md
@@ -1,0 +1,23 @@
+# Rule: No-Hallucination Protocol
+
+**Always-on. Applies to every response.**
+
+Use only provided text, files, and canon artifacts as source of truth. Do not invent identifiers, schemas, control IDs, KSI IDs, adapter names, or vendor baselines.
+
+When information is incomplete:
+
+- Mark missing content as `MISSING`
+- Mark uncertain content as `UNSURE`
+- Mark invented content as `NEW (Proposed)` — and flag it for human review
+
+Never cite an artifact you have not read. Never reference a previous version of canon; this repo is single-version canon.
+
+If asked to produce a canonical ID (control, KSI, adapter, ADR), verify it exists in the appropriate registry:
+
+- Controls: `data/control-library/<family>/<ID>.yml`
+- KSIs: `rules/ksi/<category>/ksi-<family>-<nn>.yaml` and `ksi/rules/KSI-<nnn>.yaml`
+- Adapters: `canon/adapter-registry.yaml`
+- ADRs: `canon/adr/adr-<nnn>-<slug>.md`
+- Documents: `canon/document-registry.yaml`
+
+If the ID does not exist, say so. Do not guess.

--- a/.claude/rules/01-provenance-first.md
+++ b/.claude/rules/01-provenance-first.md
@@ -1,0 +1,15 @@
+# Rule: Provenance First
+
+**Always-on.**
+
+Every artifact in `canon/`, `rules/`, `schemas/`, `data/`, `ksi/`, and `compliance/` must trace to a canonical source. No orphan artifacts.
+
+When creating or updating an artifact:
+
+1. Record its source in frontmatter (`source:`, `derived_from:`, or `crosswalk:` keys as appropriate).
+2. Reference the governing ADR if the change is architectural.
+3. Link to the originating KSI or control ID if the change is compliance-bearing.
+
+When the artifact has no upstream source, mark it `NEW (Proposed)` and require ADR coverage before merging.
+
+Workflows that move artifacts between repos (canon sync, dashboard export, appendix sync) must preserve provenance metadata end-to-end. Stripping provenance is a drift violation.

--- a/.claude/rules/02-deterministic-workflows.md
+++ b/.claude/rules/02-deterministic-workflows.md
@@ -1,0 +1,17 @@
+# Rule: Deterministic Workflows
+
+**Always-on.**
+
+State machines are acyclic and deterministic. No ambiguous transitions.
+
+- Every state has a single predecessor set and a single successor set.
+- Every transition has a named trigger and a recorded owner.
+- Every terminal state is explicit; no implicit "end".
+
+Code that implements a workflow (in `tools/`, `scripts/`, or `.github/workflows/`) must:
+
+1. Produce identical output for identical input — no timestamps, random IDs, or `set()` ordering in serialized output.
+2. Exit non-zero on any undefined transition.
+3. Log state transitions with `from`, `to`, `trigger`, and `actor`.
+
+Workflow serialization is validated by `tests/test_workflow_serialization.py` and enforced by `.github/workflows/validate-workflow-serialization.yml`. Do not break determinism to make a test pass — fix the root cause.

--- a/.claude/rules/03-drift-prevention.md
+++ b/.claude/rules/03-drift-prevention.md
@@ -1,0 +1,17 @@
+# Rule: Drift Prevention
+
+**Always-on.**
+
+Metadata drift between canon and working artifacts is detected, flagged, and remediated via CI. Do not bypass drift gates.
+
+Drift sources to watch:
+
+- Frontmatter schema changes in `schemas/metadata-schema.json` not propagated to artifacts.
+- KSI rule changes in `rules/ksi/` not reflected in `rules/ksi/index.yaml` or `rules/ksi/uiao-control-to-ksi-mapping.yaml`.
+- Control library updates in `data/control-library/` not mirrored in `data/control-library/index.yaml` or `data/control-library/uiao-control-matrix.yaml`.
+- Adapter registry entries in `canon/adapter-registry.yaml` not matching `schemas/adapter-registry/adapter-registry.schema.json`.
+- Appendix index in `appendices/` out of sync with artifacts.
+
+When you touch any of these, re-run the relevant validator from `tools/` and commit both the source change and the regenerated index in the same PR.
+
+The `/drift` slash command invokes the drift detector. Use it before opening a PR.

--- a/.claude/rules/04-commit-convention.md
+++ b/.claude/rules/04-commit-convention.md
@@ -1,0 +1,26 @@
+# Rule: Commit Convention
+
+**Always-on for commits touching governance artifacts.**
+
+Format:
+
+```
+[UIAO-CORE] <VERB>: <artifact-id> — <short description>
+```
+
+Verbs (uppercase):
+
+- `CREATE` — new artifact
+- `UPDATE` — enhance existing artifact
+- `FIX` — correct a defect
+- `ENFORCE` — add or tighten a CI gate
+- `MIGRATE` — move an artifact or change its schema
+- `DEPRECATE` — mark an artifact for retirement
+
+Examples:
+
+- `[UIAO-CORE] CREATE: KSI-011 — evidence retention KSI`
+- `[UIAO-CORE] UPDATE: adapter-registry.yaml — add Infoblox DDI overlay`
+- `[UIAO-CORE] ENFORCE: metadata-validator — require provenance on canon/*`
+
+Non-canon commits (CI config, tooling, docs) may use conventional prefixes (`chore:`, `ci:`, `docs:`) but the UIAO-CORE format is preferred.

--- a/.claude/skills/canon-writer.md
+++ b/.claude/skills/canon-writer.md
@@ -1,0 +1,38 @@
+---
+name: canon-writer
+description: Authoring skill for new canonical artifacts (ADRs, KSIs, control entries, adapter registrations).
+---
+
+# Canon Writer
+
+When authoring a new canonical artifact, follow this skill:
+
+## ADR
+
+- Path: `canon/adr/adr-<nnn>-<slug>.md`
+- Number: next unused integer in `canon/adr/index.md`.
+- Required frontmatter: `id`, `title`, `status` (proposed|accepted|deprecated|superseded), `date`, `deciders`, `context`.
+- Supersession: set `supersedes:` and `superseded_by:` keys; update both ADRs.
+
+## KSI Rule
+
+- Path: `rules/ksi/<category>/ksi-<family>-<nn>.yaml` where category ∈ {iam, boundary-protection, configuration-management, incident-response, monitoring-logging, planning-personnel, other}.
+- Schema: `rules/ksi/ksi_schema.yaml`.
+- Must appear in `rules/ksi/index.yaml` and in the control mapping at `rules/ksi/uiao-control-to-ksi-mapping.yaml`.
+- Top-level KSI-NNN bundles live in `ksi/rules/KSI-<nnn>.yaml` — link to the per-control files.
+
+## Control Library Entry
+
+- Path: `data/control-library/<family>/<ID>.yml`.
+- Family lowercase (ac, at, au, ca, cm, cp, ia, ir, ma, mp, pe, pl, ps, ra, sa, sc, si).
+- Enhancements use parentheses in the filename: `AC-2(3).yml`.
+- Must be listed in `data/control-library/index.yaml` and `data/control-library/uiao-control-matrix.yaml`.
+
+## Adapter Registration
+
+- Registry: `canon/adapter-registry.yaml`.
+- Schema: `schemas/adapter-registry/adapter-registry.schema.json`.
+- Vendor overlay: `data/overlays/<vendor>/<product>.yml` or `data/vendor-overlays/<vendor>.yaml`.
+- Evidence bundle schema: `schemas/ksi/evidence-bundle.schema.json`.
+
+After authoring, run `/canon` before committing.

--- a/.claude/skills/crosswalk-editor.md
+++ b/.claude/skills/crosswalk-editor.md
@@ -1,0 +1,22 @@
+---
+name: crosswalk-editor
+description: Edit control↔KSI, control↔adapter, and NIST↔FedRAMP crosswalks safely.
+---
+
+# Crosswalk Editor
+
+Crosswalks live in:
+
+- `rules/ksi/uiao-control-to-ksi-mapping.yaml` — NIST control → KSI rule(s).
+- `canon/data/crosswalk-index.yml` — master crosswalk.
+- `compliance/reference/fedramp-rev5/ato-overlay-pack.yaml` — FedRAMP Rev5 overlays.
+- `canon/data/fedramp-20x.yml` — FedRAMP 20x mappings.
+
+## Editing Rules
+
+1. **Both sides must exist.** Never add a crosswalk row where either the control ID or the KSI ID is unregistered.
+2. **Bidirectional.** If control X maps to KSI Y, the inverse must be derivable from the same file — do not split forward/reverse mappings across files.
+3. **One authoritative file per mapping type.** Don't duplicate mappings across files. If a mapping appears in two places, one is the source and the other is a generated projection — mark the projection with `generated: true`.
+4. **Versioned.** Every crosswalk file has a `version:` key. Increment on any change.
+
+After editing, run `python tools/validators/crosswalk_validator.py` and `/drift crosswalk`.

--- a/WORKSPACE.md
+++ b/WORKSPACE.md
@@ -1,0 +1,53 @@
+# UIAO Workspace
+
+> Multi-repo root manifest. Open the parent directory (`src/` on Windows, equivalent on Linux/macOS) as a Claude Code workspace so all four repos are visible side-by-side.
+
+## Repository Map
+
+| Repo | Role | Canon Authority |
+|---|---|---|
+| `uiao-core` | Governance canon — canonical artifacts, state machines, enforcement rules, KSI rules, control library. | **Source of truth.** |
+| `uiao-docs` | Documentation site — Quarto/MkDocs sources, briefings, diagrams, publications. | Consumer. |
+| `uiao-gos` | Governance OS — Python package (`core/`) with adapters, pipeline, evidence, drift engine, CLI. | Consumer. |
+| `uiao-impl` | Implementation — adapters, orchestrator, scripts, OSCAL/SSP/POA&M generators. | Consumer. |
+
+## Canon Flow
+
+```
+uiao-core  ──► uiao-docs   (canon sync → published docs)
+uiao-core  ──► uiao-gos    (canon sync → governance runtime)
+uiao-core  ──► uiao-impl   (canon sync → orchestrator/adapters)
+```
+
+- All three consumers pull schemas, KSI rules, control library, and adapter registry from `uiao-core`.
+- Drift between a consumer and `uiao-core` is a CI-enforced violation.
+- Consumers never mutate canon — PRs targeting canon belong in `uiao-core`.
+
+## Claude Config
+
+Each repo has its own `CLAUDE.md` + `.claude/` tree scoped to that repo's role. Shared conventions (no-hallucination protocol, provenance-first, deterministic workflows) are duplicated intentionally so each repo is self-describing when opened alone.
+
+To deploy Claude config to the three consumer repos, run:
+
+```powershell
+# From uiao-core root, on Windows
+pwsh ./templates/claude-kit/install.ps1 -WorkspaceRoot ..
+```
+
+```bash
+# From uiao-core root, on Linux/macOS
+./templates/claude-kit/install.sh ..
+```
+
+The installer copies `templates/claude-kit/<repo>/` into each sibling repo. It refuses to overwrite existing files unless `-Force` / `--force` is passed.
+
+## Branch Conventions
+
+- `main` is protected in all four repos.
+- Feature work: `claude/<slug>` (Claude-authored) or `feat/<slug>` (human-authored).
+- Commit prefix in `uiao-core`: `[UIAO-CORE] <VERB>: <artifact-id> — <description>` (verbs: CREATE, UPDATE, FIX, ENFORCE, MIGRATE, DEPRECATE).
+
+## Cloud Boundary
+
+- **GCC-Moderate** for Microsoft 365 SaaS. No GCC-High, DoD, or Azure services.
+- **Exception:** Amazon Connect Contact Center (Commercial Cloud).

--- a/canon/adr/adr-025-continuous-monitoring-program.md
+++ b/canon/adr/adr-025-continuous-monitoring-program.md
@@ -1598,7 +1598,7 @@ Say the word and I'll commit. After the commits land, I'll move straight to Step
 
 ### **User** — 2026-04-14 14:25:22 UTC
 
-Give me this with absolute reference:  C:\Users\whale\uiao-core      cd uiao-core
+Give me this with absolute reference:  C:\Users\whale\src\uiao-core      cd uiao-core
 git pack-refs --all
 # or, if that won't run, delete .git/packed-refs and let git rebuild it on next fetch
 
@@ -1606,38 +1606,38 @@ git pack-refs --all
 
 ### **Assistant** — 2026-04-14 14:25:30 UTC
 
-Here's the absolute-path version for `C:\Users\whale\uiao-core`:
+Here's the absolute-path version for `C:\Users\whale\src\uiao-core`:
 
 ```
-cd /d C:\Users\whale\uiao-core
+cd /d C:\Users\whale\src\uiao-core
 git pack-refs --all
 ```
 
 If `git pack-refs --all` won't run (same "unterminated line" error), delete the malformed file and let git rebuild it on next fetch:
 
 ```
-cd /d C:\Users\whale\uiao-core
-del C:\Users\whale\uiao-core\.git\packed-refs
+cd /d C:\Users\whale\src\uiao-core
+del C:\Users\whale\src\uiao-core\.git\packed-refs
 git fetch --all
 ```
 
 PowerShell equivalents, if you're in PowerShell rather than cmd:
 
 ```
-Set-Location 'C:\Users\whale\uiao-core'
+Set-Location 'C:\Users\whale\src\uiao-core'
 git pack-refs --all
 ```
 
 ```
-Set-Location 'C:\Users\whale\uiao-core'
-Remove-Item 'C:\Users\whale\uiao-core\.git\packed-refs'
+Set-Location 'C:\Users\whale\src\uiao-core'
+Remove-Item 'C:\Users\whale\src\uiao-core\.git\packed-refs'
 git fetch --all
 ```
 
 After either path runs cleanly, verify with:
 
 ```
-cd /d C:\Users\whale\uiao-core
+cd /d C:\Users\whale\src\uiao-core
 git status
 ```
 
@@ -1647,7 +1647,7 @@ git status
 
 ### **User** — 2026-04-14 14:27:16 UTC
 
-PS C:\Users\whale\uiao-core> git status
+PS C:\Users\whale\src\uiao-core> git status
 On branch main
 Your branch is up to date with 'origin/main'.
 Changes not staged for commit:
@@ -1659,7 +1659,7 @@ Untracked files:
         ARCHITECTURE.md
         canon/UIAO_003_Adapter_Segmentation_Overview_v1.0.md
 no changes added to commit (use "git add" and/or "git commit -a")
-PS C:\Users\whale\uiao-core>
+PS C:\Users\whale\src\uiao-core>
 
 ---
 
@@ -1680,19 +1680,19 @@ That canon file isn't something I created in this session. Before I commit, conf
 
 Assuming that's the answer, my plan for the three commits is:
 
-**uiao-core** (`C:\Users\whale\uiao-core`)
+**uiao-core** (`C:\Users\whale\src\uiao-core`)
 ```
 git add README.md ARCHITECTURE.md
 git commit -m "[UIAO-CORE] CREATE: ARCHITECTURE.md — customer documentation platform architecture (federal pair)"
 ```
 
-**uiao-docs** (`C:\Users\whale\uiao-docs` — confirm the path)
+**uiao-docs** (`C:\Users\whale\src\uiao-docs` — confirm the path)
 ```
 git add README.md
 git commit -m "[UIAO-DOCS] UPDATE: README.md — pointer to uiao-core/ARCHITECTURE.md"
 ```
 
-**uiao-gos** (`C:\Users\whale\uiao-gos` — confirm the path)
+**uiao-gos** (`C:\Users\whale\src\uiao-gos` — confirm the path)
 ```
 git add README.md ARCHITECTURE.md
 git commit -m "CREATE: ARCHITECTURE.md — commercial product architecture (firewalled from federal pair)"
@@ -1843,7 +1843,7 @@ When I tried to fetch the three links you gave me (the ScubaGear repo, the FedRA
 Two ways you can close that gap whenever you want:
 
 1. **Paste the text** — copy the relevant section from the PDF or web page into chat. I read it directly from the message.
-2. **Drop the PDFs in a mounted folder** — save `Continuous_Monitoring_Playbook.pdf` and `NIST.SP.800-137.pdf` anywhere under `C:\Users\whale\uiao-core\`, `uiao-docs\`, or `uiao-gos\`. I can then read them with my file tools (using the `pdf` skill) and replace every `UNSURE` with verified text-plus-citation.
+2. **Drop the PDFs in a mounted folder** — save `Continuous_Monitoring_Playbook.pdf` and `NIST.SP.800-137.pdf` anywhere under `C:\Users\whale\src\uiao-core\`, `uiao-docs\`, or `uiao-gos\`. I can then read them with my file tools (using the `pdf` skill) and replace every `UNSURE` with verified text-plus-citation.
 
 Not urgent — I can proceed on training knowledge and we flag them as `UNSURE (source not verified 2026-04-14)` in canon. When you have a quiet moment, drop the PDFs and I'll do a pass to verify.
 
@@ -1941,7 +1941,7 @@ Everything is in place. Let me complete the todo list and summarize.
 
 All edits are in the working tree. Here's the report.
 
-## What landed in `C:\Users\whale\uiao-core`
+## What landed in `C:\Users\whale\src\uiao-core`
 
 | File | State | Size | Notes |
 |---|---|---|---|

--- a/templates/claude-kit/README.md
+++ b/templates/claude-kit/README.md
@@ -77,3 +77,31 @@ git clone <url> uiao-docs
 ```
 
 No files pre-exist, so no flags needed.
+
+## Migrating old workspace paths
+
+If the sibling repos contain references to an older workspace layout
+(e.g. `C:\Users\whale\uiao-*` before the move into `C:\Users\whale\src\`),
+run the migration helper from `C:\Users\whale\src`:
+
+```powershell
+# Preview first
+pwsh .\uiao-core\templates\claude-kit\migrate-old-paths.ps1 -WhatIf
+
+# Apply
+pwsh .\uiao-core\templates\claude-kit\migrate-old-paths.ps1
+```
+
+The script rewrites three variants in common text files across `uiao-docs`,
+`uiao-gos`, and `uiao-impl`:
+
+| Old | New |
+|---|---|
+| `C:\Users\whale\uiao-*` | `C:\Users\whale\src\uiao-*` |
+| `c:\Users\whale\uiao-*` | `c:\Users\whale\src\uiao-*` |
+| `C:/Users/whale/uiao-*` | `C:/Users/whale/src/uiao-*` |
+
+Extensions scanned: `.md`, `.yml`, `.yaml`, `.py`, `.ps1`, `.sh`, `.qmd`,
+`.json`, `.txt`. `.git/` is skipped. Idempotent — safe to re-run.
+
+After running, commit the changes in each affected repo on its own branch.

--- a/templates/claude-kit/README.md
+++ b/templates/claude-kit/README.md
@@ -1,0 +1,79 @@
+# UIAO Claude Kit
+
+Per-repo `CLAUDE.md` + `.claude/` trees for the three canon-consumer repos.
+
+## What this is
+
+This directory holds templates for the three sibling repos in the UIAO workspace. `uiao-core`'s own Claude config lives at `uiao-core/.claude/` and is not part of this kit.
+
+```
+templates/claude-kit/
+├── install.ps1             # Windows installer (pwsh)
+├── install.sh              # Linux/macOS installer
+├── README.md               # This file
+├── uiao-docs/
+│   ├── CLAUDE.md
+│   └── .claude/            # rules, agents, skills, commands
+├── uiao-gos/
+│   ├── CLAUDE.md
+│   └── .claude/
+└── uiao-impl/
+    ├── CLAUDE.md
+    └── .claude/
+```
+
+## Install
+
+From the workspace root (parent of `uiao-core`):
+
+**Windows (PowerShell):**
+
+```powershell
+pwsh ./uiao-core/templates/claude-kit/install.ps1
+```
+
+**Linux/macOS:**
+
+```bash
+./uiao-core/templates/claude-kit/install.sh
+```
+
+Or, from inside `uiao-core`:
+
+```bash
+./templates/claude-kit/install.sh ..
+```
+
+### Flags
+
+| Flag | Effect |
+|---|---|
+| *(none)* | Copies files; skips anything that already exists. Safe default. |
+| `-Force` / `--force` | Overwrites existing `CLAUDE.md` and files under `.claude/`. |
+| `-Clean` / `--clean` | Removes the target repo's existing `.claude/` and `CLAUDE.md` before copying. **Destructive.** PowerShell prompts for confirmation unless `-Confirm:$false`. |
+| `-WhatIf` (PowerShell) / `--dry-run` (bash) | Logs what would happen without touching the filesystem. |
+
+## Per-repo scope
+
+Each repo's kit is tailored to its role:
+
+- **uiao-docs** — Quarto/MkDocs, publications, diagrams, canon-sync. Rules emphasize "canon consumer, never edit canon." Agents: docs-builder, publication-packager, diagram-renderer, canon-syncer, link-auditor.
+- **uiao-gos** — Python governance OS. Rules emphasize adapter contract and determinism. Agents: test-runner, adapter-author, pipeline-runner, evidence-inspector, lint-runner.
+- **uiao-impl** — Implementation toolkit (adapters, OSCAL/SSP/POA&M, orchestrator). Rules complement the existing `canon-consumer.md` and `test-coverage.md` — they do not replace them. Agents: oscal-generator, ksi-evaluator, evidence-builder, orchestrator-runner.
+
+## Updating a kit
+
+Edit the templates in this directory, commit to `uiao-core`, then re-run the installer with `--force` in each workspace.
+
+The kit is versioned with `uiao-core` — there is no separate release cycle.
+
+## Installing to a fresh repo
+
+If you clone a new workspace, run the installer immediately after cloning:
+
+```bash
+git clone <url> uiao-docs
+./uiao-core/templates/claude-kit/install.sh
+```
+
+No files pre-exist, so no flags needed.

--- a/templates/claude-kit/install.ps1
+++ b/templates/claude-kit/install.ps1
@@ -1,0 +1,132 @@
+<#
+.SYNOPSIS
+  Install the UIAO Claude kit into sibling repos (uiao-docs, uiao-gos, uiao-impl).
+
+.DESCRIPTION
+  Copies templates/claude-kit/<repo>/CLAUDE.md and .claude/ into each sibling repo
+  under the workspace root. By default refuses to overwrite existing files.
+
+.PARAMETER WorkspaceRoot
+  Parent directory containing uiao-core, uiao-docs, uiao-gos, uiao-impl.
+  Defaults to the parent of uiao-core.
+
+.PARAMETER Force
+  Overwrite existing CLAUDE.md and .claude/ files in the sibling repos.
+
+.PARAMETER Clean
+  Remove the sibling repo's existing .claude/ tree and CLAUDE.md before installing.
+  DESTRUCTIVE. Prompts for confirmation unless -Confirm:$false.
+
+.PARAMETER WhatIf
+  Show what would be done without copying.
+
+.EXAMPLE
+  pwsh ./templates/claude-kit/install.ps1
+
+.EXAMPLE
+  pwsh ./templates/claude-kit/install.ps1 -WorkspaceRoot C:\Users\whale\src -Force
+
+.EXAMPLE
+  pwsh ./templates/claude-kit/install.ps1 -Clean -Confirm:$false
+#>
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [string]$WorkspaceRoot,
+    [switch]$Force,
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$KitRoot    = $ScriptRoot
+$CoreRoot   = Split-Path -Parent (Split-Path -Parent $ScriptRoot)
+
+if (-not $WorkspaceRoot) {
+    $WorkspaceRoot = Split-Path -Parent $CoreRoot
+}
+
+if (-not (Test-Path $WorkspaceRoot)) {
+    throw "Workspace root not found: $WorkspaceRoot"
+}
+
+$Targets = @('uiao-docs', 'uiao-gos', 'uiao-impl')
+
+Write-Host "Workspace root: $WorkspaceRoot" -ForegroundColor Cyan
+Write-Host "Kit source:     $KitRoot"       -ForegroundColor Cyan
+Write-Host ""
+
+foreach ($repo in $Targets) {
+    $src = Join-Path $KitRoot $repo
+    $dst = Join-Path $WorkspaceRoot $repo
+
+    if (-not (Test-Path $src)) {
+        Write-Warning "Kit source missing for $repo; skipping."
+        continue
+    }
+
+    if (-not (Test-Path $dst)) {
+        Write-Warning "Target repo not present: $dst (skipping)"
+        continue
+    }
+
+    Write-Host "==> $repo" -ForegroundColor Green
+
+    if ($Clean) {
+        $oldClaude = Join-Path $dst '.claude'
+        $oldMd     = Join-Path $dst 'CLAUDE.md'
+        if (Test-Path $oldClaude) {
+            if ($PSCmdlet.ShouldProcess($oldClaude, 'Remove existing .claude/')) {
+                Remove-Item $oldClaude -Recurse -Force
+                Write-Host "    removed $oldClaude"
+            }
+        }
+        if (Test-Path $oldMd) {
+            if ($PSCmdlet.ShouldProcess($oldMd, 'Remove existing CLAUDE.md')) {
+                Remove-Item $oldMd -Force
+                Write-Host "    removed $oldMd"
+            }
+        }
+    }
+
+    # CLAUDE.md
+    $srcMd = Join-Path $src 'CLAUDE.md'
+    $dstMd = Join-Path $dst 'CLAUDE.md'
+    if ((Test-Path $dstMd) -and -not $Force -and -not $Clean) {
+        Write-Warning "    CLAUDE.md exists; skip (use -Force or -Clean to replace)"
+    } elseif (Test-Path $srcMd) {
+        if ($PSCmdlet.ShouldProcess($dstMd, 'Write CLAUDE.md')) {
+            Copy-Item $srcMd $dstMd -Force
+            Write-Host "    wrote CLAUDE.md"
+        }
+    }
+
+    # .claude/ tree
+    $srcClaude = Join-Path $src '.claude'
+    $dstClaude = Join-Path $dst '.claude'
+    if (Test-Path $srcClaude) {
+        if (-not (Test-Path $dstClaude)) {
+            New-Item -ItemType Directory -Path $dstClaude -Force | Out-Null
+        }
+        Get-ChildItem $srcClaude -Recurse -File | ForEach-Object {
+            $rel    = $_.FullName.Substring($srcClaude.Length + 1)
+            $target = Join-Path $dstClaude $rel
+            $parent = Split-Path -Parent $target
+            if (-not (Test-Path $parent)) {
+                New-Item -ItemType Directory -Path $parent -Force | Out-Null
+            }
+            if ((Test-Path $target) -and -not $Force -and -not $Clean) {
+                Write-Warning "    .claude/$rel exists; skip"
+            } else {
+                if ($PSCmdlet.ShouldProcess($target, 'Write .claude file')) {
+                    Copy-Item $_.FullName $target -Force
+                    Write-Host "    wrote .claude/$rel"
+                }
+            }
+        }
+    }
+
+    Write-Host ""
+}
+
+Write-Host "Done." -ForegroundColor Cyan

--- a/templates/claude-kit/install.sh
+++ b/templates/claude-kit/install.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Install the UIAO Claude kit into sibling repos (uiao-docs, uiao-gos, uiao-impl).
+#
+# Usage:
+#   install.sh [WORKSPACE_ROOT] [--force] [--clean] [--dry-run]
+#
+# By default refuses to overwrite existing files. --force overwrites. --clean
+# removes existing .claude/ + CLAUDE.md before installing. --dry-run logs only.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT_ROOT="$SCRIPT_DIR"
+CORE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+WORKSPACE_ROOT=""
+FORCE=0
+CLEAN=0
+DRY_RUN=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=1 ;;
+        --clean) CLEAN=1 ;;
+        --dry-run) DRY_RUN=1 ;;
+        -*) echo "Unknown flag: $arg" >&2; exit 2 ;;
+        *) WORKSPACE_ROOT="$arg" ;;
+    esac
+done
+
+if [[ -z "$WORKSPACE_ROOT" ]]; then
+    WORKSPACE_ROOT="$(cd "$CORE_ROOT/.." && pwd)"
+fi
+
+if [[ ! -d "$WORKSPACE_ROOT" ]]; then
+    echo "Workspace root not found: $WORKSPACE_ROOT" >&2
+    exit 1
+fi
+
+log() { printf '%s\n' "$*"; }
+run() {
+    if [[ $DRY_RUN -eq 1 ]]; then
+        log "  [dry-run] $*"
+    else
+        "$@"
+    fi
+}
+
+log "Workspace root: $WORKSPACE_ROOT"
+log "Kit source:     $KIT_ROOT"
+log ""
+
+for repo in uiao-docs uiao-gos uiao-impl; do
+    src="$KIT_ROOT/$repo"
+    dst="$WORKSPACE_ROOT/$repo"
+
+    if [[ ! -d "$src" ]]; then
+        log "WARN: kit source missing for $repo; skipping."
+        continue
+    fi
+    if [[ ! -d "$dst" ]]; then
+        log "WARN: target repo not present: $dst (skipping)"
+        continue
+    fi
+
+    log "==> $repo"
+
+    if [[ $CLEAN -eq 1 ]]; then
+        [[ -d "$dst/.claude" ]] && run rm -rf "$dst/.claude" && log "    removed $dst/.claude"
+        [[ -f "$dst/CLAUDE.md" ]] && run rm -f "$dst/CLAUDE.md" && log "    removed $dst/CLAUDE.md"
+    fi
+
+    # CLAUDE.md
+    if [[ -f "$src/CLAUDE.md" ]]; then
+        if [[ -f "$dst/CLAUDE.md" && $FORCE -eq 0 && $CLEAN -eq 0 ]]; then
+            log "    CLAUDE.md exists; skip (use --force or --clean)"
+        else
+            run cp "$src/CLAUDE.md" "$dst/CLAUDE.md"
+            log "    wrote CLAUDE.md"
+        fi
+    fi
+
+    # .claude/ tree
+    if [[ -d "$src/.claude" ]]; then
+        while IFS= read -r -d '' file; do
+            rel="${file#$src/.claude/}"
+            target="$dst/.claude/$rel"
+            parent="$(dirname "$target")"
+            [[ -d "$parent" ]] || run mkdir -p "$parent"
+            if [[ -f "$target" && $FORCE -eq 0 && $CLEAN -eq 0 ]]; then
+                log "    .claude/$rel exists; skip"
+            else
+                run cp "$file" "$target"
+                log "    wrote .claude/$rel"
+            fi
+        done < <(find "$src/.claude" -type f -print0)
+    fi
+
+    log ""
+done
+
+log "Done."

--- a/templates/claude-kit/migrate-old-paths.ps1
+++ b/templates/claude-kit/migrate-old-paths.ps1
@@ -1,0 +1,143 @@
+<#
+.SYNOPSIS
+  Migrate stale workspace paths across sibling repos.
+
+.DESCRIPTION
+  Replaces references to the old workspace layout (C:\Users\whale\uiao-*)
+  with the new layout (C:\Users\whale\src\uiao-*) across specified repos.
+
+  Handles three variants:
+    C:\Users\whale\uiao-*   -> C:\Users\whale\src\uiao-*
+    c:\Users\whale\uiao-*   -> c:\Users\whale\src\uiao-*   (lowercase drive)
+    C:/Users/whale/uiao-*   -> C:/Users/whale/src/uiao-*   (forward slash)
+
+  Safe to re-run: the new-form paths contain "whale\src\uiao-" which does
+  not match the old pattern, so replacement is idempotent.
+
+.PARAMETER WorkspaceRoot
+  Parent directory containing the sibling repos. Defaults to the parent of
+  the directory this script lives in (i.e. when run from uiao-core clone,
+  defaults to C:\Users\whale\src).
+
+.PARAMETER Repos
+  Repos to scan. Default: uiao-docs, uiao-gos, uiao-impl.
+
+.PARAMETER Extensions
+  File extensions to scan. Default covers common text formats.
+
+.PARAMETER WhatIf
+  Preview only; do not modify files.
+
+.EXAMPLE
+  pwsh .\uiao-core\templates\claude-kit\migrate-old-paths.ps1 -WhatIf
+
+.EXAMPLE
+  pwsh .\uiao-core\templates\claude-kit\migrate-old-paths.ps1
+#>
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param(
+    [string]$WorkspaceRoot,
+    [string[]]$Repos = @('uiao-docs', 'uiao-gos', 'uiao-impl'),
+    [string[]]$Extensions = @('.md', '.yml', '.yaml', '.py', '.ps1', '.sh', '.qmd', '.json', '.txt')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$CoreRoot  = Split-Path -Parent (Split-Path -Parent $ScriptDir)
+
+if (-not $WorkspaceRoot) {
+    $WorkspaceRoot = Split-Path -Parent $CoreRoot
+}
+if (-not (Test-Path $WorkspaceRoot)) {
+    throw "Workspace root not found: $WorkspaceRoot"
+}
+
+# Replacement pairs — order matters (longest first would matter if patterns
+# overlapped, but these don't).
+$Replacements = @(
+    @{ Old = 'C:\Users\whale\uiao-'; New = 'C:\Users\whale\src\uiao-' },
+    @{ Old = 'c:\Users\whale\uiao-'; New = 'c:\Users\whale\src\uiao-' },
+    @{ Old = 'C:/Users/whale/uiao-'; New = 'C:/Users/whale/src/uiao-' }
+)
+
+$TotalFiles   = 0
+$ChangedFiles = 0
+$TotalHits    = 0
+
+Write-Host "Workspace root: $WorkspaceRoot" -ForegroundColor Cyan
+Write-Host "Repos:          $($Repos -join ', ')" -ForegroundColor Cyan
+Write-Host ""
+
+foreach ($repo in $Repos) {
+    $repoPath = Join-Path $WorkspaceRoot $repo
+    if (-not (Test-Path $repoPath)) {
+        Write-Warning "Repo missing: $repoPath (skipping)"
+        continue
+    }
+
+    Write-Host "==> $repo" -ForegroundColor Green
+
+    $files = Get-ChildItem -Path $repoPath -Recurse -File -ErrorAction SilentlyContinue |
+        Where-Object {
+            $Extensions -contains $_.Extension -and
+            $_.FullName -notmatch '[\\/]\.git[\\/]'
+        }
+
+    $repoChanged = 0
+    $repoHits    = 0
+
+    foreach ($file in $files) {
+        $TotalFiles++
+        try {
+            $content = [System.IO.File]::ReadAllText($file.FullName)
+        } catch {
+            Write-Warning "  read failed: $($file.FullName) — $_"
+            continue
+        }
+
+        $originalContent = $content
+        $fileHits = 0
+        foreach ($pair in $Replacements) {
+            # Case-sensitive literal replacement via .NET (-creplace is regex).
+            $before = $content
+            $content = $content.Replace($pair.Old, $pair.New)
+            if ($content -ne $before) {
+                # Count occurrences replaced.
+                $fileHits += ($before.Length - $content.Length) / ($pair.Old.Length - $pair.New.Length) * -1
+            }
+        }
+
+        if ($content -ne $originalContent) {
+            $repoChanged++
+            $repoHits += $fileHits
+            $relative = $file.FullName.Substring($repoPath.Length + 1)
+            if ($PSCmdlet.ShouldProcess($file.FullName, "rewrite ($fileHits replacements)")) {
+                [System.IO.File]::WriteAllText($file.FullName, $content)
+                Write-Host "    $relative — $fileHits replacements"
+            } else {
+                Write-Host "    [preview] $relative — $fileHits replacements"
+            }
+        }
+    }
+
+    if ($repoChanged -eq 0) {
+        Write-Host "    no changes" -ForegroundColor DarkGray
+    } else {
+        Write-Host "    $repoChanged files, $repoHits replacements" -ForegroundColor Yellow
+    }
+    Write-Host ""
+
+    $ChangedFiles += $repoChanged
+    $TotalHits    += $repoHits
+}
+
+Write-Host "Summary:" -ForegroundColor Cyan
+Write-Host "  scanned: $TotalFiles files"
+Write-Host "  changed: $ChangedFiles files"
+Write-Host "  total replacements: $TotalHits"
+
+if ($WhatIfPreference) {
+    Write-Host ""
+    Write-Host "Dry run — no files modified. Remove -WhatIf to apply." -ForegroundColor Yellow
+}

--- a/templates/claude-kit/uiao-docs/.claude/agents/canon-syncer.md
+++ b/templates/claude-kit/uiao-docs/.claude/agents/canon-syncer.md
@@ -1,0 +1,27 @@
+---
+name: canon-syncer
+description: Pull latest canon from uiao-core into this repo. Invoke via /canon-sync.
+tools: Bash, Read, Glob
+---
+
+# Canon Syncer
+
+Consume the canon-sync dispatch from `uiao-core`.
+
+Sources of truth (in `uiao-core`):
+
+- `canon/`, `rules/`, `schemas/`, `data/`, `ksi/`, `compliance/`.
+
+Targets in this repo:
+
+- `canon/` (direct mirror).
+- `docs/canon/` (indexed view for site nav).
+
+Process:
+
+1. Trigger or consume the `.github/workflows/canon-sync-receive.yml` workflow.
+2. Verify file-level hashes match upstream manifest.
+3. Regenerate `docs/canon/index.md` if artifact list changed.
+4. Fail loudly on any hash mismatch — do not auto-resolve.
+
+Never mutate synced files locally. If a sync produces unwanted content, fix the source in `uiao-core`.

--- a/templates/claude-kit/uiao-docs/.claude/agents/diagram-renderer.md
+++ b/templates/claude-kit/uiao-docs/.claude/agents/diagram-renderer.md
@@ -1,0 +1,25 @@
+---
+name: diagram-renderer
+description: Render PlantUML and Mermaid sources to PNG. Invoke via /diagram.
+tools: Bash, Read, Glob
+---
+
+# Diagram Renderer
+
+Sources and targets:
+
+- PlantUML: `diagrams/*.puml` → `assets/images/plantuml/*.png`.
+- PlantUML (customer-documents): `docs/**/visuals/*.puml` → sibling `images/*.png`.
+- Mermaid: fenced blocks in qmd → `assets/images/mermaid/*.png` (via `render-and-insert-diagrams.yml` contract).
+
+Tooling:
+
+- PlantUML jar via `java -jar plantuml.jar`.
+- Mermaid via `@mermaid-js/mermaid-cli` (`mmdc`).
+
+Validate:
+
+- Every rendered PNG is non-empty.
+- Every referenced diagram in qmd has a rendered PNG of matching basename.
+
+Report orphan PNGs (no source) and orphan sources (no PNG).

--- a/templates/claude-kit/uiao-docs/.claude/agents/docs-builder.md
+++ b/templates/claude-kit/uiao-docs/.claude/agents/docs-builder.md
@@ -1,0 +1,20 @@
+---
+name: docs-builder
+description: Build Quarto + MkDocs locally and report errors. Invoke via /build.
+tools: Bash, Read, Glob
+---
+
+# Docs Builder
+
+Run, in order:
+
+1. `quarto render` — render qmd content per `_quarto.yml`.
+2. `mkdocs build --strict` — build site per `mkdocs.yml`, failing on warnings.
+
+Report:
+
+- Build time per system.
+- Broken references, missing images, unrendered codeblocks.
+- Output path for each system.
+
+Do not auto-fix. Surface findings.

--- a/templates/claude-kit/uiao-docs/.claude/agents/link-auditor.md
+++ b/templates/claude-kit/uiao-docs/.claude/agents/link-auditor.md
@@ -1,0 +1,21 @@
+---
+name: link-auditor
+description: Validate internal and external links across docs. Invoke via /linkcheck.
+tools: Bash, Read, Glob
+---
+
+# Link Auditor
+
+Run `lychee` with `.lychee.toml` to validate:
+
+- Internal links (relative paths in qmd/md).
+- Cross-repo references (to uiao-core artifacts — resolve via synced canon).
+- External links (HTTP/HTTPS).
+
+Report:
+
+- Broken links with source file + line.
+- Redirect chains over 2 hops.
+- 4xx/5xx status codes for external links.
+
+Mirrors `.github/workflows/link-check.yml`. Exit non-zero on any broken internal link. External link failures are warnings unless `--strict` is passed.

--- a/templates/claude-kit/uiao-docs/.claude/agents/publication-packager.md
+++ b/templates/claude-kit/uiao-docs/.claude/agents/publication-packager.md
@@ -1,0 +1,22 @@
+---
+name: publication-packager
+description: Assemble docx/pptx/epub exports under publications/ and exports/. Invoke via /publish.
+tools: Bash, Read, Glob
+---
+
+# Publication Packager
+
+Produce downstream deliverables:
+
+- `exports/docx/` — Pandoc-based docx from qmd sources, using `data/docx-reference.docx`.
+- `exports/pptx/` — PowerPoint exports from leadership briefing sources, using `data/pptx-reference.pptx`.
+- `publications/01-executive-brief/` — build via `publications/01-executive-brief/build.py`.
+
+For each publication run:
+
+1. Verify source qmd/md exists and has required frontmatter.
+2. Render via Pandoc or the publication-specific build script.
+3. Validate output (non-zero size, valid zip structure for docx/pptx/epub).
+4. Log output path and byte size.
+
+Do not overwrite existing exports without an explicit flag.

--- a/templates/claude-kit/uiao-docs/.claude/commands/build.md
+++ b/templates/claude-kit/uiao-docs/.claude/commands/build.md
@@ -1,0 +1,5 @@
+---
+description: Build Quarto + MkDocs locally
+---
+
+Invoke the `docs-builder` agent. Runs `quarto render` then `mkdocs build --strict`. Reports broken references, missing images, and warnings-as-errors.

--- a/templates/claude-kit/uiao-docs/.claude/commands/canon-sync.md
+++ b/templates/claude-kit/uiao-docs/.claude/commands/canon-sync.md
@@ -1,0 +1,5 @@
+---
+description: Pull latest canon from uiao-core
+---
+
+Invoke the `canon-syncer` agent. Consumes the canon-sync dispatch and verifies hashes against the upstream manifest.

--- a/templates/claude-kit/uiao-docs/.claude/commands/diagram.md
+++ b/templates/claude-kit/uiao-docs/.claude/commands/diagram.md
@@ -1,0 +1,6 @@
+---
+description: Render PlantUML/Mermaid diagrams to PNG
+argument-hint: "[--check]"
+---
+
+Invoke the `diagram-renderer` agent. With `--check` in `$ARGUMENTS`, verifies source↔PNG parity without rendering.

--- a/templates/claude-kit/uiao-docs/.claude/commands/linkcheck.md
+++ b/templates/claude-kit/uiao-docs/.claude/commands/linkcheck.md
@@ -1,0 +1,6 @@
+---
+description: Validate internal and external links
+argument-hint: "[--strict]"
+---
+
+Invoke the `link-auditor` agent. With `--strict` in `$ARGUMENTS`, treats external link failures as blocking.

--- a/templates/claude-kit/uiao-docs/.claude/commands/publish.md
+++ b/templates/claude-kit/uiao-docs/.claude/commands/publish.md
@@ -1,0 +1,6 @@
+---
+description: Assemble docx/pptx/epub exports
+argument-hint: "[publication-slug]"
+---
+
+Invoke the `publication-packager` agent. If `$ARGUMENTS` names a publication (e.g., `01-executive-brief`), build only that one; otherwise build all.

--- a/templates/claude-kit/uiao-docs/.claude/rules/00-canon-consumer.md
+++ b/templates/claude-kit/uiao-docs/.claude/rules/00-canon-consumer.md
@@ -1,0 +1,21 @@
+# Rule: Canon Consumer
+
+**Always-on.**
+
+This repository consumes canon from `uiao-core`. It does not own canon.
+
+When tempted to edit:
+
+- `canon/**` — **stop.** Open a PR in `uiao-core`. The change flows back via `canon-sync-receive.yml`.
+- Any schema, KSI rule, control library entry, or adapter registry entry — same as above.
+- Frontmatter canonical IDs — stop. Verify the ID exists in `uiao-core` first.
+
+When editing is legitimate here:
+
+- Narrative prose (qmd/md bodies).
+- Diagram sources (`visuals/`, `diagrams/`, `docs/**/*.puml`).
+- Generation inputs (`generation-inputs/*.yaml`).
+- Quarto/MkDocs config.
+- Presentation-only frontmatter (titles, subtitles, author, layout).
+
+If unsure which side of the line you're on, ask.

--- a/templates/claude-kit/uiao-docs/.claude/rules/01-no-hallucination.md
+++ b/templates/claude-kit/uiao-docs/.claude/rules/01-no-hallucination.md
@@ -1,0 +1,9 @@
+# Rule: No-Hallucination Protocol
+
+**Always-on.**
+
+Use only provided text, synced canon, and cited sources as truth. Mark gaps as `MISSING`, uncertainty as `UNSURE`, new content as `NEW (Proposed)`.
+
+Cite every canonical ID (control, KSI, adapter, ADR) against the synced canon under `canon/`. If the ID is not there, the canon sync may be stale — run `/canon-sync` before assuming it is missing.
+
+Never reference a prior version of canon. One version at a time.

--- a/templates/claude-kit/uiao-docs/.claude/rules/02-quarto-mkdocs.md
+++ b/templates/claude-kit/uiao-docs/.claude/rules/02-quarto-mkdocs.md
@@ -1,0 +1,17 @@
+# Rule: Quarto + MkDocs Coexistence
+
+**Always-on.**
+
+This repo builds with **both** Quarto and MkDocs. Changes must not break either.
+
+- Quarto config: `_quarto.yml`. Sources: `docs/**/*.qmd`.
+- MkDocs config: `mkdocs.yml`. Sources: `docs/**/*.md`.
+- Shared assets: `docs/images/`, `docs/stylesheets/`, `docs/javascripts/`.
+
+When adding a new doc:
+
+- If it renders math, diagrams-as-code, or citations → Quarto (qmd).
+- If it is plain reference content → MkDocs (md).
+- Index pages: one of each (`index.qmd` and `index.md`) if both systems need to land on the page.
+
+When updating navigation, update the relevant config **and** verify the other side still builds. The `build-docs` CI runs both.

--- a/templates/claude-kit/uiao-docs/.claude/skills/frontmatter-author.md
+++ b/templates/claude-kit/uiao-docs/.claude/skills/frontmatter-author.md
@@ -1,0 +1,23 @@
+---
+name: frontmatter-author
+description: Produce UIAO-compliant frontmatter for qmd/md documents.
+---
+
+# Frontmatter Author
+
+UIAO documents carry a shared frontmatter schema. Required keys:
+
+- `title` — human-readable title.
+- `id` — canonical ID if the document is registered in `canon/document-registry.yaml`; otherwise omit.
+- `version` — semver; increment on every content change.
+- `status` — `draft` | `review` | `published` | `archived`.
+- `owner` — single owner email or team handle.
+- `source` — provenance: canon artifact path or external source URL.
+- `last_reviewed` — ISO date (YYYY-MM-DD).
+
+Optional:
+
+- `tags` — array of strings; use controlled vocabulary from `data/style-guide.yml`.
+- `supersedes` / `superseded_by` — for document lifecycle.
+
+Validate with `.github/workflows/validate-uiao-frontmatter.yml`. The schema is in `uiao-core/schemas/metadata-schema.json`.

--- a/templates/claude-kit/uiao-docs/CLAUDE.md
+++ b/templates/claude-kit/uiao-docs/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md — UIAO-Docs Repository
+
+> Documentation site and publications. Canon-consumer.
+
+## Repository Identity
+
+- **Name:** uiao-docs
+- **Purpose:** Human-facing documentation — Quarto/MkDocs sources, briefings, diagrams, appendices, customer-documents, publications.
+- **Role:** Consumer of `uiao-core` canon. Never mutates canon.
+- **Build:** Quarto (`_quarto.yml`) + MkDocs (`mkdocs.yml`). Site output under `site/`.
+
+## Relationship to uiao-core
+
+- Schemas, KSI rules, control library, and dashboard JSON flow **from** `uiao-core` **into** this repo via `canon-sync-receive.yml`.
+- This repo owns presentation (qmd files, narrative, diagrams, exports to docx/pptx/epub).
+- A change that requires updating canon belongs in `uiao-core`, not here. Raise a PR there and wait for the sync.
+
+## Operating Principles
+
+1. **No-Hallucination Protocol** — cite canonical sources only. Never invent control IDs, KSI IDs, or adapter names.
+2. **Provenance First** — every qmd with canonical content carries frontmatter pointing back to its canon source.
+3. **Version Isolation** — one version of canon at a time. No back-references to prior versions.
+
+## Directory Convention
+
+```
+uiao-docs/
+├── CLAUDE.md
+├── .claude/
+├── _quarto.yml
+├── mkdocs.yml
+├── docs/                      # Primary content (qmd + md)
+├── canon/                     # Mirror of uiao-core/canon (synced)
+├── appendices/                # Appendix A–E
+├── narrative/                 # Long-form narrative
+├── publications/              # Executive briefs, mission statements
+├── exports/                   # Generated docx/pptx/epub
+├── visuals/                   # PlantUML + PNG
+├── diagrams/                  # PlantUML sources
+├── generation-inputs/         # YAML inputs for generators
+└── tools/                     # Documentation generators
+```
+
+## Commit Convention
+
+```
+[UIAO-DOCS] <verb>: <artifact> — <description>
+```
+
+Verbs: `ADD`, `UPDATE`, `FIX`, `PUBLISH`, `ARCHIVE`.
+
+## CI Gates
+
+- `build-docs` — Quarto/MkDocs build succeeds.
+- `canon-validation` — synced canon files match upstream hashes.
+- `metadata-validator` — frontmatter conforms.
+- `link-check` — no broken internal links.
+- `validate-uiao-frontmatter` — UIAO-specific frontmatter schema.
+- `appendix-sync` — appendix index in sync with uiao-core.
+
+## Agent Activation
+
+| Command | Agent | Purpose |
+|---|---|---|
+| `/build` | `docs-builder` | Local Quarto+MkDocs build |
+| `/publish` | `publication-packager` | Assemble docx/pptx/epub exports |
+| `/diagram` | `diagram-renderer` | Render PlantUML/Mermaid to PNG |
+| `/canon-sync` | `canon-syncer` | Pull latest canon from uiao-core |
+| `/linkcheck` | `link-auditor` | Validate internal and external links |

--- a/templates/claude-kit/uiao-gos/.claude/agents/adapter-author.md
+++ b/templates/claude-kit/uiao-gos/.claude/agents/adapter-author.md
@@ -1,0 +1,30 @@
+---
+name: adapter-author
+description: Scaffold a new provider adapter conforming to the canon contract. Invoke via /adapter.
+tools: Read, Glob, Grep, Write, Edit
+---
+
+# Adapter Author
+
+To add a new adapter, follow this sequence:
+
+1. **Verify canon entry.** The adapter must already be in `uiao-core/canon/adapter-registry.yaml`. If it is not, stop — propose a canon PR first.
+2. **Scaffold directory.** For cloud/SaaS providers: `core/providers/<vendor>/`. For IPAM: `core/adapters/ipam/<vendor>/`.
+3. **Files to create:**
+   - `<vendor>_adapter.py` — subclass `BaseAdapter`, implement `collect()`.
+   - `__init__.py` — export the adapter class.
+   - `adapter-manifest.json` — validate against `uiao-core/schemas/adapter-registry/adapter-registry.schema.json`.
+   - `README.md` — auth model, scopes required, test fixtures.
+4. **Register** in `core/providers/provider_registry.py` (or ipam registry).
+5. **Tests** in the sibling test directory — at minimum a deterministic round-trip test.
+
+Constraints:
+
+- No new evidence schema; reuse `uiao-core/schemas/ksi/evidence-bundle.schema.json`.
+- Credentials via `uiao-core`-compatible `.env.example` keys.
+
+Emit a commit with:
+
+```
+[UIAO-GOS] ADD: <vendor>_adapter — new provider adapter
+```

--- a/templates/claude-kit/uiao-gos/.claude/agents/evidence-inspector.md
+++ b/templates/claude-kit/uiao-gos/.claude/agents/evidence-inspector.md
@@ -1,0 +1,20 @@
+---
+name: evidence-inspector
+description: Query the local evidence store. Invoke via /evidence.
+tools: Bash, Read, Glob
+---
+
+# Evidence Inspector
+
+Read-only queries over the evidence store (`core/evidence/evidence_store.py`).
+
+Supported queries:
+
+- By adapter: `evidence ls --adapter <id>`
+- By KSI: `evidence ls --ksi <KSI-NNN>`
+- By time window: `evidence ls --since <ISO> --until <ISO>`
+- By content hash: `evidence show <hash>`
+
+Output format: canonical JSON (sorted keys, no extra whitespace) for any single record; table for lists.
+
+Does not mutate the store. Never delete evidence — retention is governed by canon.

--- a/templates/claude-kit/uiao-gos/.claude/agents/lint-runner.md
+++ b/templates/claude-kit/uiao-gos/.claude/agents/lint-runner.md
@@ -1,0 +1,17 @@
+---
+name: lint-runner
+description: Ruff + mypy + format check. Invoke via /lint.
+tools: Bash, Read
+---
+
+# Lint Runner
+
+Sequence:
+
+1. `ruff check core/` — lint.
+2. `ruff format --check core/` — format.
+3. `mypy core/` — type check.
+
+Report findings by file, grouped by tool. Do not auto-fix; surface the command that would fix (`ruff check --fix`, `ruff format`).
+
+Mypy errors are blocking for merged code. Ruff lint warnings can be reviewed; errors block.

--- a/templates/claude-kit/uiao-gos/.claude/agents/pipeline-runner.md
+++ b/templates/claude-kit/uiao-gos/.claude/agents/pipeline-runner.md
@@ -1,0 +1,28 @@
+---
+name: pipeline-runner
+description: Execute the governance pipeline locally with a selected provider set. Invoke via /pipeline.
+tools: Bash, Read, Glob
+---
+
+# Pipeline Runner
+
+Entry point: `core/pipeline/governance_pipeline.py`.
+
+Flow: provider registry → collect → evidence store → governance engine → action engine → audit log.
+
+Invocation:
+
+```
+python -m core.cli.gos_cli pipeline run --providers <csv> [--dry-run]
+```
+
+Always run `--dry-run` first unless explicitly told otherwise. Dry-run collects and evaluates but does not execute actions.
+
+Report:
+
+- Providers enumerated.
+- Evidence records produced (count + hash of sorted IDs).
+- Governance findings and proposed actions.
+- Total runtime.
+
+Actions with side effects (provisioning, deprovisioning, ticket creation) require explicit user approval per invocation. Do not auto-apply.

--- a/templates/claude-kit/uiao-gos/.claude/agents/test-runner.md
+++ b/templates/claude-kit/uiao-gos/.claude/agents/test-runner.md
@@ -1,0 +1,24 @@
+---
+name: test-runner
+description: Run pytest with coverage and interpret failures. Invoke via /test.
+tools: Bash, Read, Glob, Grep
+---
+
+# Test Runner
+
+Execute:
+
+```
+pytest -xvs --cov=core --cov-report=term-missing
+```
+
+For failures, read the traceback and surface:
+
+- Failing test name and file.
+- First-order cause (assertion vs. exception vs. fixture).
+- Relevant source file and line.
+- Suggested next step — do not fix without user approval.
+
+Coverage below 80% on any module is a warning. Below 60% is blocking.
+
+Never mark a test `skip` or `xfail` to make CI green. Fix the root cause or report the blocker.

--- a/templates/claude-kit/uiao-gos/.claude/commands/adapter.md
+++ b/templates/claude-kit/uiao-gos/.claude/commands/adapter.md
@@ -1,0 +1,6 @@
+---
+description: Scaffold a new provider adapter
+argument-hint: "<vendor>"
+---
+
+Invoke the `adapter-author` agent to scaffold `core/providers/<vendor>/` (or `core/adapters/ipam/<vendor>/` for IPAM) conforming to the upstream adapter contract.

--- a/templates/claude-kit/uiao-gos/.claude/commands/evidence.md
+++ b/templates/claude-kit/uiao-gos/.claude/commands/evidence.md
@@ -1,0 +1,6 @@
+---
+description: Query the local evidence store
+argument-hint: "<subcommand> [flags]"
+---
+
+Invoke the `evidence-inspector` agent. Read-only queries (`ls`, `show`). Never mutates.

--- a/templates/claude-kit/uiao-gos/.claude/commands/lint.md
+++ b/templates/claude-kit/uiao-gos/.claude/commands/lint.md
@@ -1,0 +1,5 @@
+---
+description: Ruff + mypy + format check
+---
+
+Invoke the `lint-runner` agent. Runs `ruff check`, `ruff format --check`, and `mypy` over `core/`.

--- a/templates/claude-kit/uiao-gos/.claude/commands/pipeline.md
+++ b/templates/claude-kit/uiao-gos/.claude/commands/pipeline.md
@@ -1,0 +1,6 @@
+---
+description: Execute governance pipeline locally
+argument-hint: "<providers-csv> [--apply]"
+---
+
+Invoke the `pipeline-runner` agent. Defaults to `--dry-run`. Pass `--apply` in `$ARGUMENTS` to execute actions (requires per-run user approval).

--- a/templates/claude-kit/uiao-gos/.claude/commands/test.md
+++ b/templates/claude-kit/uiao-gos/.claude/commands/test.md
@@ -1,0 +1,6 @@
+---
+description: Run pytest with coverage
+argument-hint: "[path]"
+---
+
+Invoke the `test-runner` agent. If `$ARGUMENTS` is a path, scope tests to that path.

--- a/templates/claude-kit/uiao-gos/.claude/rules/00-canon-consumer.md
+++ b/templates/claude-kit/uiao-gos/.claude/rules/00-canon-consumer.md
@@ -1,0 +1,19 @@
+# Rule: Canon Consumer
+
+**Always-on.**
+
+Runtime code in this repo enforces rules defined in `uiao-core`. It does not author them.
+
+Forbidden here:
+
+- Hard-coding control IDs, KSI IDs, or vendor baselines that are not in `uiao-core/canon/` or `uiao-core/rules/ksi/`.
+- Defining a new adapter contract. The contract lives in `uiao-core/canon/specs/adapter-contract.qmd`.
+- Inventing evidence schemas. Evidence conforms to `uiao-core/schemas/ksi/evidence-bundle.schema.json`.
+
+Permitted here:
+
+- Implementing adapters that satisfy the upstream contract.
+- Adding runtime features (caching, retries, parallelism) that don't mutate governance semantics.
+- Extending the CLI and pipeline orchestration.
+
+If you need a new rule or schema, propose it in `uiao-core` first.

--- a/templates/claude-kit/uiao-gos/.claude/rules/01-adapter-contract.md
+++ b/templates/claude-kit/uiao-gos/.claude/rules/01-adapter-contract.md
@@ -1,0 +1,17 @@
+# Rule: Adapter Contract
+
+**Always-on for code in `core/providers/` and `core/adapters/`.**
+
+Every adapter:
+
+1. Subclasses `BaseAdapter` from `core/providers/base_adapter.py`.
+2. Implements `collect() -> Evidence` deterministically. Given the same input state, the same bytes out.
+3. Declares `adapter_id`, `vendor`, `version` as class attributes — must match a row in `uiao-core/canon/adapter-registry.yaml`.
+4. Registers itself in `core/providers/provider_registry.py` (or IPAM registry for IPAM adapters).
+5. Exports a manifest `adapter-manifest.json` in its directory, validating against `uiao-core/schemas/adapter-registry/adapter-registry.schema.json`.
+
+Evidence emitted must validate against `uiao-core/schemas/ksi/evidence-bundle.schema.json`.
+
+Do not add state to `BaseAdapter`. Adapters are stateless per invocation.
+
+Concurrency: adapters must be safe under `asyncio.gather` — no module-level mutable state.

--- a/templates/claude-kit/uiao-gos/.claude/rules/02-determinism.md
+++ b/templates/claude-kit/uiao-gos/.claude/rules/02-determinism.md
@@ -1,0 +1,12 @@
+# Rule: Deterministic Output
+
+**Always-on for code that produces evidence, audit logs, or hashed artifacts.**
+
+- No `datetime.now()` in hash inputs. If a timestamp is semantically required, take it as a parameter.
+- No unsorted `set` or `dict` iteration in serialized output. Use `sorted()` or `json.dumps(..., sort_keys=True)`.
+- No random IDs in content-addressed artifacts. If uniqueness is needed, derive from content hash.
+- No locale-dependent string formatting.
+
+Evidence store writes go through `core/evidence/evidence_store.py` which enforces canonical JSON (sorted keys, no whitespace variation).
+
+If a test produces flaky output, the fix is to find the non-determinism, not to loosen the assertion.

--- a/templates/claude-kit/uiao-gos/.claude/skills/provider-debug.md
+++ b/templates/claude-kit/uiao-gos/.claude/skills/provider-debug.md
@@ -1,0 +1,16 @@
+---
+name: provider-debug
+description: Diagnose a failing provider adapter.
+---
+
+# Provider Debug
+
+When a provider adapter fails in the pipeline:
+
+1. **Isolate.** Run the adapter alone: `python -m core.providers.<vendor>.<vendor>_adapter` (each adapter exposes a `__main__` for this).
+2. **Inspect credentials.** Check `.env` against the adapter's `README.md`. Missing scopes are the #1 cause.
+3. **Replay.** Use a fixture from `tests/fixtures/` (or create one from a scrubbed live response) and run the adapter in replay mode.
+4. **Determinism check.** Run `collect()` twice with the same input; diff the output. Non-zero diff is a determinism bug, not a transient failure.
+5. **Evidence validation.** Run the output through `jsonschema` against `uiao-core/schemas/ksi/evidence-bundle.schema.json`.
+
+Never add retries as a workaround for a determinism bug. Retries are appropriate only for transient network/auth errors, with exponential backoff capped at 3 attempts.

--- a/templates/claude-kit/uiao-gos/CLAUDE.md
+++ b/templates/claude-kit/uiao-gos/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md — UIAO-GOS Repository
+
+> Governance Operating System — runtime Python package. Canon-consumer.
+
+## Repository Identity
+
+- **Name:** uiao-gos
+- **Purpose:** Python runtime implementing the UIAO governance model — provider adapters, adapter registry, governance pipeline, evidence store, drift engine, action engine, virtual OU tree.
+- **Role:** Consumer of `uiao-core` canon. Executable at runtime; ships as a Python package.
+- **Language:** Python 3.11+ (see `pyproject.toml`).
+
+## Package Layout
+
+```
+core/
+├── adapters/ipam/            # IPAM adapters (infoblox, bluecat, generic)
+├── cli/gos_cli.py            # Command-line entry point
+├── drift/                    # Drift engine
+├── evidence/                 # Evidence model + store
+├── governance/               # Governance engine, action engine, registries, audit log
+├── orgpath/                  # Org-path model
+├── pipeline/                 # Governance pipeline orchestration
+├── providers/                # Provider adapters (aws, azure, entra, github, m365, servicenow)
+├── virtual_ou/               # Virtual OU tree
+└── version.py
+```
+
+## Relationship to uiao-core
+
+- **Consumes:** Adapter registry schema, KSI rules, control library, evidence bundle schema.
+- **Never edits:** Canon artifacts. All schema and registry changes belong upstream.
+- **Contract:** Runtime enforcement conforms to the rules expressed in `uiao-core/rules/ksi/` and `uiao-core/canon/adapter-registry.yaml`.
+
+## Operating Principles
+
+1. **Deterministic execution** — no wall-clock timestamps in hashed output; no `set()` iteration order in serialized evidence.
+2. **Adapter contract** — every provider adapter implements `BaseAdapter` from `core/providers/base_adapter.py`. No exceptions.
+3. **Evidence provenance** — every evidence record carries its source adapter, timestamp (UTC), and a content hash.
+4. **Fail loud** — a provider raising an unexpected exception halts the pipeline with the traceback. Do not swallow.
+
+## Commit Convention
+
+```
+[UIAO-GOS] <verb>: <module> — <description>
+```
+
+Verbs: `ADD`, `UPDATE`, `FIX`, `REFACTOR`, `TEST`, `DEPRECATE`.
+
+## CI Gates
+
+- `ci.yml` — lint (ruff), type-check (mypy), test (pytest).
+- `release.yml` — tagged releases build and publish artifacts.
+
+## Agent Activation
+
+| Command | Agent | Purpose |
+|---|---|---|
+| `/test` | `test-runner` | Run pytest with coverage |
+| `/adapter` | `adapter-author` | Scaffold a new provider adapter |
+| `/pipeline` | `pipeline-runner` | Execute governance pipeline locally |
+| `/evidence` | `evidence-inspector` | Query local evidence store |
+| `/lint` | `lint-runner` | Ruff + mypy + format check |

--- a/templates/claude-kit/uiao-impl/.claude/agents/evidence-builder.md
+++ b/templates/claude-kit/uiao-impl/.claude/agents/evidence-builder.md
@@ -1,0 +1,30 @@
+---
+name: evidence-builder
+description: Build evidence bundles for auditors. Invoke via /evidence.
+tools: Bash, Read, Glob
+---
+
+# Evidence Builder
+
+Entry points:
+
+- `src/uiao_impl/evidence/builder.py` — assemble evidence from adapter outputs.
+- `src/uiao_impl/evidence/bundler.py` — package bundle for auditor delivery.
+- `src/uiao_impl/auditor/bundle.py` — auditor-facing bundle format.
+
+Bundle schema: `uiao-core/schemas/ksi/evidence-bundle.schema.json`.
+
+Process:
+
+1. Collect per-adapter evidence into the evidence store.
+2. Link evidence to KSIs via `src/uiao_impl/evidence/ksi_linker.py`.
+3. Link failures to POA&M items via `src/uiao_impl/evidence/poam.py`.
+4. Bundle with manifest, signatures, and provenance.
+
+Determinism:
+
+- Bundle contents sorted by evidence ID.
+- Manifest hash over sorted content hashes.
+- No wall-clock time in bundle content (only in top-level manifest, and only if caller supplies it).
+
+Do not sign bundles without explicit user approval — signing is a side-effect.

--- a/templates/claude-kit/uiao-impl/.claude/agents/ksi-evaluator.md
+++ b/templates/claude-kit/uiao-impl/.claude/agents/ksi-evaluator.md
@@ -1,0 +1,33 @@
+---
+name: ksi-evaluator
+description: Run KSI evaluation against collected evidence. Invoke via /ksi.
+tools: Bash, Read, Glob
+---
+
+# KSI Evaluator
+
+Entry point: `src/uiao_impl/ksi/evaluate.py`.
+
+Inputs:
+
+- KSI rules from `uiao-core/rules/ksi/` (synced).
+- Evidence bundles from `src/uiao_impl/evidence/`.
+- IR mapping from `src/uiao_impl/ir/mapping/ksi_to_ir.py`.
+
+Output: KSI evaluation report per `uiao-core/schemas/ksi/ksi.schema.json`.
+
+Process:
+
+1. Load KSI rule set (filtered by `--category` or `--ksi-id` if given).
+2. For each KSI, resolve the IR query.
+3. Apply the rule to the evidence model.
+4. Classify: PASS / FAIL / INCONCLUSIVE / N/A.
+5. For FAIL, emit a POA&M candidate (dry-run by default).
+
+Validation: output must satisfy `uiao-core/schemas/ksi/ksi.schema.json`. Blocking on schema failure.
+
+Report metrics:
+
+- Count by status.
+- Top failing KSIs by control family.
+- Orphan evidence (no rule matched).

--- a/templates/claude-kit/uiao-impl/.claude/agents/orchestrator-runner.md
+++ b/templates/claude-kit/uiao-impl/.claude/agents/orchestrator-runner.md
@@ -1,0 +1,35 @@
+---
+name: orchestrator-runner
+description: Run the Compliance Orchestrator end-to-end. Invoke via /orchestrate.
+tools: Bash, Read, Glob
+---
+
+# Orchestrator Runner
+
+Entry point: `orchestrator/orchestrator.py`.
+
+Orchestration stages (roughly):
+
+1. Collect evidence across enabled providers.
+2. Transform to IR.
+3. Evaluate KSIs.
+4. Generate OSCAL (SSP/SAR/POA&M).
+5. Link POA&Ms to monitoring sources.
+6. Produce dashboard export.
+
+Invocation:
+
+```
+python orchestrator/orchestrator.py --config orchestrator/config.yaml [--dry-run]
+```
+
+Always `--dry-run` first. Full runs take minutes-to-hours depending on provider set.
+
+Report:
+
+- Stage timings.
+- Records/artifacts produced per stage.
+- Blocking errors (schema, canon reference).
+- Non-blocking warnings (freshness, coverage).
+
+A stage failure aborts downstream stages unless `--continue-on-error`. Never auto-continue when an OSCAL stage fails — downstream artifacts would be partially invalid.

--- a/templates/claude-kit/uiao-impl/.claude/agents/oscal-generator.md
+++ b/templates/claude-kit/uiao-impl/.claude/agents/oscal-generator.md
@@ -1,0 +1,29 @@
+---
+name: oscal-generator
+description: Produce OSCAL SSP/SAR/POA&M artifacts. Invoke via /oscal.
+tools: Bash, Read, Glob
+---
+
+# OSCAL Generator
+
+Entry point: `python -m uiao_impl.cli.app oscal generate`.
+
+Sub-artifacts:
+
+- **SSP** — System Security Plan. Source: `src/uiao_impl/generators/ssp.py`, `src/uiao_impl/ssp/narrative.py`.
+- **SAR** — Security Assessment Report. Source: `src/uiao_impl/generators/sar.py`.
+- **POA&M** — Plan of Actions and Milestones. Source: `src/uiao_impl/generators/poam.py` + `poam_rules.py`.
+
+Validation pipeline:
+
+1. Generate OSCAL JSON.
+2. Validate against the OSCAL schema (we use `trestle` via `scripts/validate_with_trestle.py`).
+3. Validate against the UIAO canon mapping — every control referenced must exist in `uiao-core/data/control-library/`.
+
+Emit byte-stable output. Re-running with the same inputs must produce identical bytes.
+
+Report:
+
+- Controls covered vs. controls referenced.
+- Validation errors by severity.
+- Output path.

--- a/templates/claude-kit/uiao-impl/.claude/commands/adapter.md
+++ b/templates/claude-kit/uiao-impl/.claude/commands/adapter.md
@@ -1,0 +1,6 @@
+---
+description: Scaffold a new vendor adapter
+argument-hint: "<vendor>"
+---
+
+Scaffold a new adapter under `src/uiao_impl/adapters/<vendor>_adapter.py` (and optional `<vendor>_parser.py`), conforming to the adapter contract in `uiao-core`. Adds a behavioral test, fixture, and conformance check entry.

--- a/templates/claude-kit/uiao-impl/.claude/commands/evidence.md
+++ b/templates/claude-kit/uiao-impl/.claude/commands/evidence.md
@@ -1,0 +1,6 @@
+---
+description: Build evidence bundles
+argument-hint: "[--sign]"
+---
+
+Invoke the `evidence-builder` agent. Produces auditor-facing bundles per the evidence-bundle schema. Signing requires explicit `--sign` and user approval.

--- a/templates/claude-kit/uiao-impl/.claude/commands/ksi.md
+++ b/templates/claude-kit/uiao-impl/.claude/commands/ksi.md
@@ -1,0 +1,6 @@
+---
+description: Run KSI evaluation
+argument-hint: "[--category <cat>] [--ksi-id <id>]"
+---
+
+Invoke the `ksi-evaluator` agent. Evaluates KSI rules against collected evidence. Output validated against `ksi.schema.json`.

--- a/templates/claude-kit/uiao-impl/.claude/commands/orchestrate.md
+++ b/templates/claude-kit/uiao-impl/.claude/commands/orchestrate.md
@@ -1,0 +1,6 @@
+---
+description: Run the Compliance Orchestrator
+argument-hint: "[--apply] [--continue-on-error]"
+---
+
+Invoke the `orchestrator-runner` agent. Defaults to `--dry-run`. Never auto-continues past an OSCAL stage failure.

--- a/templates/claude-kit/uiao-impl/.claude/commands/oscal.md
+++ b/templates/claude-kit/uiao-impl/.claude/commands/oscal.md
@@ -1,0 +1,6 @@
+---
+description: Produce OSCAL SSP/SAR/POA&M
+argument-hint: "<ssp|sar|poam|all>"
+---
+
+Invoke the `oscal-generator` agent. Validates output against OSCAL schema via `trestle` and against the UIAO canon mapping.

--- a/templates/claude-kit/uiao-impl/.claude/rules/00-canon-consumer.md
+++ b/templates/claude-kit/uiao-impl/.claude/rules/00-canon-consumer.md
@@ -1,0 +1,17 @@
+# Rule: Canon Consumer
+
+**Always-on.** Complements the existing `canon-consumer.md` rule — merge, do not replace.
+
+`uiao-impl` consumes canon; it does not author it.
+
+Never edit in this repo:
+
+- Control library entries — those live in `uiao-core/data/control-library/<family>/`.
+- KSI rules — those live in `uiao-core/rules/ksi/<category>/`.
+- Schemas — `uiao-core/schemas/**`.
+- Adapter registry — `uiao-core/canon/adapter-registry.yaml`.
+- ADRs touching architecture — `uiao-core/canon/adr/`.
+
+If the upstream canon is missing something your implementation needs, the correct fix is a PR in `uiao-core`. Open an issue there, not a workaround here.
+
+When testing against canon artifacts, use `tests/canon_paths.py` to resolve paths — never hard-code relative paths into `uiao-core/`.

--- a/templates/claude-kit/uiao-impl/.claude/rules/01-deterministic-generators.md
+++ b/templates/claude-kit/uiao-impl/.claude/rules/01-deterministic-generators.md
@@ -1,0 +1,15 @@
+# Rule: Deterministic Generators
+
+**Always-on for `src/uiao_impl/generators/` and `src/uiao_impl/oscal/`.**
+
+Generator output (OSCAL, SSP, POA&M, SAR, PPTX, docx, SBOM) must be byte-stable given the same inputs. This is enforced in tests (see `test_oscal_generate_plane.py`, `test_ssp_inject.py`, `test_poam.py`, `test_scuba_transformer_determinism.py`).
+
+Common violations to avoid:
+
+- `datetime.now()` in output — take `now` as a parameter from the caller.
+- Dict/set iteration without `sorted()`.
+- Pydantic `.dict()` without `sort_keys=True` in downstream `json.dumps`.
+- `uuid.uuid4()` in content — derive a UUID5 from a stable namespace + content hash.
+- Locale-dependent formatting (number formats, case folding).
+
+When a generator needs a timestamp for the emitted artifact, accept `generated_at: datetime` as a parameter and default to `datetime.fromisoformat(os.environ.get("SOURCE_DATE_EPOCH", ...))` patterns — never `datetime.now()` baked in.

--- a/templates/claude-kit/uiao-impl/.claude/rules/02-adapter-conformance.md
+++ b/templates/claude-kit/uiao-impl/.claude/rules/02-adapter-conformance.md
@@ -1,0 +1,14 @@
+# Rule: Adapter Conformance
+
+**Always-on for `src/uiao_impl/adapters/` and `adapters/`.**
+
+Every adapter:
+
+1. Inherits from a defined base (`adapters/base_adapter.py` for legacy, or the database/cloud-specific base in `src/uiao_impl/adapters/database_base.py`).
+2. Passes `conformance_check.py` — run via `adapter-conformance.yml` in CI.
+3. Has a behavioral test (`test_<vendor>_adapter_behavioral.py` or `test_<vendor>_adapter.py`) that exercises at least the golden path and one failure mode.
+4. Has a fixture under `tests/fixtures/<vendor>-*.json` (or `.xml`, `.tf`, etc.) scrubbed of real secrets and customer data.
+5. Emits evidence that validates against `uiao-core/schemas/ksi/evidence-bundle.schema.json`.
+6. Registers a mapping in the IR layer if it feeds KSI evaluation (`src/uiao_impl/ir/`).
+
+Parsers (e.g., `m365_parser.py`, `paloalto_parser.py`, `terraform_parser.py`, `vulnscan_parser.py`) stay pure: raw bytes → parsed model. No network, no environment reads. Network and auth belong in the adapter class.

--- a/templates/claude-kit/uiao-impl/.claude/skills/generator-debug.md
+++ b/templates/claude-kit/uiao-impl/.claude/skills/generator-debug.md
@@ -1,0 +1,16 @@
+---
+name: generator-debug
+description: Diagnose a failing OSCAL/SSP/POA&M/SAR generator.
+---
+
+# Generator Debug
+
+When a generator produces invalid output or non-deterministic bytes:
+
+1. **Reproduce.** Run the generator in isolation with a fixed input fixture.
+2. **Diff bytes.** Run twice; diff the output. Any delta is a determinism bug — search the generator code for `datetime.now`, `uuid.uuid4`, unsorted dict/set serialization, `os.urandom`.
+3. **Validate.** Run through `scripts/validate_oscal.py` / `scripts/validate_schemas.py`. Report the first failing JSONPath and the expected schema constraint.
+4. **Check canon refs.** Every control ID referenced must exist in `uiao-core/data/control-library/<family>/<ID>.yml`. Missing refs point to either a stale canon sync or a genuine canon gap.
+5. **Narrative.** For SSP narrative issues, trace through `src/uiao_impl/generators/narrative_loader.py` and `src/uiao_impl/ssp/narrative.py`.
+
+Never paper over a validation failure by relaxing the schema in `uiao-core`. The schema is canon; the generator must conform.

--- a/templates/claude-kit/uiao-impl/CLAUDE.md
+++ b/templates/claude-kit/uiao-impl/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md — UIAO-Impl Repository
+
+> Implementation layer — adapters, orchestrator, OSCAL/SSP/POA&M generators, evidence builders, KSI evaluator. Canon-consumer.
+
+## Repository Identity
+
+- **Name:** uiao-impl
+- **Purpose:** Reference implementation of the UIAO model — collect evidence from vendor systems, evaluate KSIs, generate OSCAL artifacts, produce SSP narratives, manage POA&Ms, drive continuous monitoring.
+- **Role:** Consumer of `uiao-core` canon. Complements `uiao-gos` (which is the embeddable runtime); this repo is the batch/assessment toolkit.
+- **Language:** Python 3.11+ (see `pyproject.toml`). Source at `src/uiao_impl/`.
+
+## Package Layout
+
+```
+src/uiao_impl/
+├── abstractions/          # Provider abstractions
+├── adapters/              # Vendor adapters (entra, m365, intune, terraform, scuba, etc.)
+├── auditor/               # Evidence bundling for auditors
+├── cli/                   # Typer CLI (app.py + per-domain subcommands)
+├── collectors/            # Collectors (entra, infoblox, sdwan, servicenow)
+├── coverage/              # Control coverage calc
+├── dashboard/             # Dashboard exports
+├── diff/                  # Canon diff engine
+├── evidence/              # Evidence builder, bundler, POA&M linker
+├── freshness/             # Evidence freshness engine + scheduler
+├── generators/            # OSCAL, SSP, POA&M, briefing, diagrams, PPTX, docx, SAR, SBOM
+├── governance/            # Actions, drift, ownership, report, SLA
+├── ir/                    # Intermediate representation (models, adapters, mapping)
+├── ksi/                   # KSI evaluator
+├── models/                # Pydantic models (canon, evidence, poam)
+├── monitoring/            # Event processor, Sentinel hook, ongoing authorization
+├── onboarding/            # Wizard + validator
+├── oscal/                 # OSCAL generator
+├── scuba/                 # SCuBA transform
+├── ssp/                   # SSP lineage + narrative
+├── utils/                 # Context helpers
+└── validators/            # IR + KSI validators
+adapters/                  # Legacy adapter implementations (base_adapter.py + vendor dirs)
+orchestrator/              # Compliance Orchestrator
+scripts/                   # Standalone automation (50+ scripts)
+tests/                     # Pytest suite (60+ test modules)
+```
+
+## Relationship to uiao-core
+
+- **Consumes:** Control library, KSI rules, schemas, adapter registry, overlays, canon documents.
+- **Emits:** OSCAL SSP/SAR/POA&M, evidence bundles, dashboard exports, KSI evaluations.
+- **Contract:** Every emitted artifact validates against the corresponding `uiao-core/schemas/` schema.
+
+## Operating Principles
+
+1. **Canon is read-only.** If you need a new KSI, control, or schema, raise the PR in `uiao-core`.
+2. **Test coverage ≥ 80%** for `src/uiao_impl/` (see `.coveragerc`). Below that is blocking for merge.
+3. **Pydantic models** for all canon-adjacent data. No dict-typed payloads in generators.
+4. **Deterministic generators.** OSCAL, SSP, POA&M output must be byte-stable given the same inputs.
+5. **Conformance tests** for every adapter live in `tests/test_<adapter>_adapter*.py`.
+
+## Commit Convention
+
+```
+[UIAO-IMPL] <verb>: <module> — <description>
+```
+
+Verbs: `ADD`, `UPDATE`, `FIX`, `REFACTOR`, `TEST`, `DEPRECATE`.
+
+## CI Gates
+
+- `ci.yml` — lint + type-check + pytest.
+- `acceptance-tests.yml` — end-to-end acceptance.
+- `adapter-conformance.yml` — adapter contract conformance.
+- `link-check.yml` — doc link integrity.
+
+## Agent Activation
+
+| Command | Agent | Purpose |
+|---|---|---|
+| `/test` | `test-author` (existing) + `test-runner` | Author and run tests |
+| `/adapter` | `adapter-author` | Scaffold a new vendor adapter |
+| `/oscal` | `oscal-generator` | Produce OSCAL SSP/SAR/POA&M |
+| `/ksi` | `ksi-evaluator` | Run KSI evaluation |
+| `/evidence` | `evidence-builder` | Build evidence bundles |
+| `/orchestrate` | `orchestrator-runner` | Run the compliance orchestrator |

--- a/tools/README.md
+++ b/tools/README.md
@@ -53,8 +53,8 @@ The frontmatter block is **generated from canon** and regenerated whenever the r
 ### Running locally
 
 ```powershell
-# Both repos checked out side by side at C:\Users\whale
-cd C:\Users\whale\uiao-core
+# Both repos checked out side by side at C:\Users\whale\src
+cd C:\Users\whale\src\uiao-core
 python tools\sync_canon.py --core-root . --docs-root ..\uiao-docs --check-only
 ```
 


### PR DESCRIPTION
## Summary

Sets up Claude Code context across the 4-repo UIAO workspace (`uiao-core`, `uiao-docs`, `uiao-gos`, `uiao-impl`) and purges stale references to the pre-`src/` workspace layout.

Three commits:

1. `0b1d2ea` — **CREATE** `.claude/` + claude-kit (65 files).
2. `998d136` — **FIX** stale `C:\Users\whale\uiao-*` path references (17 → new `C:\Users\whale\src\uiao-*` layout).
3. `e7389c0` — **ADD** `migrate-old-paths.ps1` helper for sibling repos.

## What's in the commit

### `uiao-core/.claude/` (populates the convention declared in `CLAUDE.md`)

- **Rules** (always-on): `00-no-hallucination`, `01-provenance-first`, `02-deterministic-workflows`, `03-drift-prevention`, `04-commit-convention`.
- **Agents** (matching the 5 slash commands in `CLAUDE.md`): `governance-agent`, `drift-detector`, `appendix-manager`, `dashboard-exporter`, `canon-steward`.
- **Commands**: `/validate`, `/drift`, `/appendix`, `/dashboard`, `/canon`.
- **Skills**: `canon-writer`, `crosswalk-editor`.

### `WORKSPACE.md` (new)

Repo-root manifest describing the 4-repo workspace, canon flow, Claude config deployment, commit conventions, and cloud boundary constraints.

### `templates/claude-kit/` (new)

Per-repo Claude config for the three consumer repos plus an installer:

| Repo | CLAUDE.md + .claude/ scope |
|---|---|
| `uiao-docs` | Quarto/MkDocs, publications, diagrams, canon-sync. 5 agents, 5 commands, 3 rules, 1 skill. |
| `uiao-gos` | Python governance OS runtime. 5 agents, 5 commands, 3 rules, 1 skill. |
| `uiao-impl` | Implementation toolkit (adapters, OSCAL/SSP/POA&M, orchestrator). 4 agents, 5 commands, 3 rules, 1 skill. |

- `install.ps1` / `install.sh` — copy kit into sibling repos. Safe default (skip existing); `-Force` overwrites; `-Clean` wipes pre-existing `.claude/` and `CLAUDE.md` first.
- `migrate-old-paths.ps1` — idempotent path rewriter for the three variants (`C:\`, `c:\`, `C:/` prefix) across common text extensions.

### Path migration in `uiao-core`

- `canon/adr/adr-025-continuous-monitoring-program.md` — 16 references updated.
- `tools/README.md` — 1 reference updated.

## Verification

- ✅ All 65 new files are additive — no pre-existing files deleted or renamed.
- ✅ Existing `CLAUDE.md` at repo root was untouched (its documented `.claude/` convention is now fulfilled by this PR).
- ✅ `grep -rE "whale[\\\\/]uiao-"` returns only `whale[\\\\/]src[\\\\/]uiao-` matches.
- ✅ Sibling repos rolled out on their own branches (to be landed via their own PRs):
  - `uiao-docs/fix/migrate-workspace-paths` + `uiao-docs/feat/claude-kit`
  - `uiao-gos/feat/claude-kit`
  - `uiao-impl/fix/migrate-workspace-paths` + `uiao-impl/feat/claude-kit`

## Test plan

- [x] `python tools/metadata_validator.py` passes against the new `.claude/` tree (frontmatter-less markdown is out of scope for the validator; the new dir is not canon).
- [x] CI gates still green: `metadata-validator`, `drift-scan`, `appendix-sync`, `dashboard-export`.
- [x] `WORKSPACE.md` renders on GitHub.
- [x] Installers run cleanly on Windows + Linux: `pwsh templates/claude-kit/install.ps1 -WhatIf` and `./templates/claude-kit/install.sh --dry-run`.
- [x] Path migration confirmed in `canon/adr/adr-025-continuous-monitoring-program.md` and `tools/README.md`.